### PR TITLE
build: bump MSRV to 1.92.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = ["crates/*", "examples/*"]
 package.edition = "2021"
-package.rust-version = "1.85.0"
+package.rust-version = "1.92.0"
 package.license = "Apache-2.0"
 package.repository = "https://github.com/juspay/framework-libs-rs"
 


### PR DESCRIPTION
This PR bumps MSRV to 1.92.0 to allow for some dependency upgrades.