### PR TITLE
feat: introduce `metrics_utils` crate for OpenTelemetry metrics instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,14 +55,26 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -95,7 +113,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -175,6 +193,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -284,7 +304,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -298,7 +318,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -309,7 +329,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -320,7 +340,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -369,7 +389,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -378,7 +398,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -399,7 +419,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -419,7 +439,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -504,6 +524,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +616,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -672,7 +702,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1589,6 +1619,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1689,99 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.5",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "hyperswitch_masking"
@@ -1856,7 +1998,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1872,6 +2014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
 ]
 
 [[package]]
@@ -1907,9 +2059,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -1991,7 +2143,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2010,10 +2162,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.1.1"
+name = "metrics_utils"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-prometheus",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prometheus",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2066,6 +2243,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "js-sys",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0359983e7f79cf33c9abd89e5d7ddf67c46c419d0148598022d70e70c01aba"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,10 +2345,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2152,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2174,7 +2450,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2193,6 +2469,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -2215,7 +2505,16 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2415,7 +2714,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2455,7 +2754,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2534,6 +2833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,12 +2868,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2613,6 +2918,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,7 +2942,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2638,22 +2960,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2725,29 +3047,134 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "flate2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2781,7 +3208,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2835,6 +3262,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -2982,6 +3415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,7 +3479,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3136,7 +3578,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3147,7 +3589,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3180,16 +3622,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3207,31 +3640,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3241,22 +3657,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3265,22 +3669,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3289,22 +3681,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3313,22 +3693,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -3366,7 +3734,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3382,7 +3750,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3449,7 +3817,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3470,7 +3838,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3490,7 +3858,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3530,7 +3898,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3544,3 +3912,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ However, we aim to keep these libraries generic enough so that they remain usefu
 
 - [`log_utils`](crates/log_utils/): A configurable logging infrastructure built on the [`tracing`](https://github.com/tokio-rs/tracing) ecosystem.
 - [`build_info`](crates/build_info/): Utilities for extracting information about the build environment and Cargo workspace.
+- [`metrics_utils`](crates/metrics_utils/): Utilities for configuring and managing [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-rust) metrics pipelines with OTLP and Prometheus export.
 - [`hyperswitch_masking`](crates/hyperswitch_masking/): Personally Identifiable Information (PII) protection through wrapper types and traits for secret management, ensuring sensitive data isn't accidentally exposed in logs or debug output.
 
 ## Roadmap
@@ -24,9 +25,9 @@ We plan to expand this collection with additional utilities commonly needed in p
 - [ ] `log_utils`:
   - [x] Add support for the [`tracing`](https://github.com/tokio-rs/tracing) ecosystem
   - [ ] Add support for the [`fastrace`](https://github.com/fast/fastrace) ecosystem
-- [ ] Metrics support:
-  - [ ] Support for pushing metrics in OpenTelemetry format with the `opentelemetry` ecosystem
-  - [ ] Support for exposing metrics in Prometheus format
+- [x] Metrics support:
+  - [x] Support for exporting metrics over OTLP
+  - [x] Support for Prometheus pull-based metrics export
 - [ ] HTTP client utilities
   - [ ] Optionally, include metrics support
 - [ ] HTTP server utilities

--- a/crates/metrics_utils/Cargo.toml
+++ b/crates/metrics_utils/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "metrics_utils"
+description = "Utilities for metrics in Rust applications"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+readme = "README.md"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
+
+[features]
+opentelemetry = ["dep:opentelemetry", "dep:thiserror", "dep:tracing"]
+opentelemetry-internal-logs = [
+    "opentelemetry?/internal-logs",
+    "opentelemetry_sdk?/internal-logs",
+    "opentelemetry-otlp?/internal-logs",
+    "opentelemetry-prometheus?/internal-logs",
+]
+opentelemetry-otlp = ["opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
+opentelemetry-otlp-gzip = ["opentelemetry-otlp?/gzip-tonic"]
+opentelemetry-otlp-zstd = ["opentelemetry-otlp?/zstd-tonic"]
+opentelemetry-prometheus = ["opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-prometheus", "dep:prometheus"]
+opentelemetry-semantic-conventions = ["dep:opentelemetry-semantic-conventions"]
+
+[dependencies]
+opentelemetry = { version = "0.32.0", optional = true, default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.32.1", optional = true, default-features = false, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.32.0", optional = true, default-features = false, features = ["metrics", "grpc-tonic"] }
+opentelemetry-prometheus = { version = "0.32.0", optional = true, default-features = false }
+opentelemetry-semantic-conventions = { version = "0.32.1", optional = true }
+prometheus = { version = "0.14.0", optional = true, default-features = false }
+thiserror = { version = "2.0.19", optional = true }
+tracing = { version = "0.1.44", optional = true, default-features = false, features = ["std"] }
+
+[dev-dependencies]
+tokio = { version = "1.53.1", default-features = false, features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/metrics_utils/README.md
+++ b/crates/metrics_utils/README.md
@@ -1,0 +1,51 @@
+# metrics_utils
+
+A thin configuration and lifecycle layer over the [OpenTelemetry Rust SDK][opentelemetry-rust-github] for application metrics.
+
+It initializes and manages an [`SdkMeterProvider`][otel-sdk-meter-provider-docs] with optional OTLP and Prometheus exporters.
+It also provides macros for declaring meters, instruments, and metric attributes without requiring direct `opentelemetry` references at each call site.
+
+## What this crate provides
+
+- **One-call pipeline initialization** through `init_metrics()`, which configures the [`SdkMeterProvider`][otel-sdk-meter-provider-docs], one [`MetricReader`][otel-metric-reader-docs] per configured exporter, and the corresponding OTLP or Prometheus exporters.
+- **Metrics pipeline lifecycle management** through `MetricsHandle`, including global provider registration, Prometheus registry access, and shutdown.
+- **Instrumentation macros** (`global_meter!`, `counter_metric!`, `histogram_metric_f64!`, `gauge_metric!`, `up_down_counter_metric!`, `metric_attributes!`, and `metric_attributes_vec!`) for defining meters, instruments, and metric attribute sets.
+
+This crate simplifies pipeline setup without replacing the OpenTelemetry instrumentation API: instruments retain their standard types and use the usual `.add()` and `.record()` methods.
+
+## Feature Flags
+
+- `opentelemetry`: Enables the OpenTelemetry core crate dependency and the macros.
+- `opentelemetry-otlp`: Enables the OTLP exporter (implies `opentelemetry`).
+  - `opentelemetry-otlp-gzip`: Enables gzip compression for the OTLP gRPC transport when `opentelemetry-otlp` is also enabled.
+  - `opentelemetry-otlp-zstd`: Enables zstd compression for the OTLP gRPC transport when `opentelemetry-otlp` is also enabled.
+- `opentelemetry-prometheus`: Enables the Prometheus pull exporter and re-exports the [`prometheus`][prometheus-docs] crate (implies `opentelemetry`).
+- `opentelemetry-internal-logs`: Enables diagnostic logging for OpenTelemetry crates already activated by other features.
+- `opentelemetry-semantic-conventions`: Re-exports the [`opentelemetry-semantic-conventions`][opentelemetry_semantic_conventions-docs] crate for standard OpenTelemetry attribute names.
+
+## Usage and Examples
+
+Refer to the crate documentation in the [`src/lib.rs`][lib-rs] file for examples and usage information.
+
+## Runtime behavior
+
+- `init_metrics()` does not set the global meter provider.
+  Call `MetricsHandle::register_as_global()` before first accessing meters or instruments declared through the global instrumentation macros.
+  Otherwise, they may be initialized as no-op instruments and recorded measurements will be discarded.
+- When OTLP and Prometheus are both configured, their readers share the same `SdkMeterProvider`.
+- `MetricsHandle` has a single owner and does not implement `Clone`.
+  Wrap it in an `Arc` when shared access is required.
+- The Prometheus exporter does not serve an HTTP endpoint.
+  Use `MetricsHandle::prometheus_registry()` to access the registry and expose it from the application, typically at `/metrics`.
+
+## License
+
+Licensed under [Apache-2.0][license].
+
+[opentelemetry-rust-github]: https://github.com/open-telemetry/opentelemetry-rust
+[otel-sdk-meter-provider-docs]: https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.SdkMeterProvider.html
+[otel-metric-reader-docs]: https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/reader/trait.MetricReader.html
+[prometheus-docs]: https://docs.rs/prometheus/latest/prometheus/
+[opentelemetry_semantic_conventions-docs]: https://docs.rs/opentelemetry-semantic-conventions/latest/opentelemetry_semantic_conventions/
+[lib-rs]: src/lib.rs
+[license]: ../../LICENSE

--- a/crates/metrics_utils/src/lib.rs
+++ b/crates/metrics_utils/src/lib.rs
@@ -1,0 +1,134 @@
+//! `metrics_utils` provides utilities for instrumenting Rust applications with OpenTelemetry
+//! metrics.
+//!
+//! When the `opentelemetry-otlp` or `opentelemetry-prometheus` feature is enabled, this crate
+//! provides:
+//!
+//! - A [`MetricsConfig`] struct for configuring the metrics system.
+//! - An [`init_metrics()`] function to construct the metrics pipeline from configuration.
+//! - A [`MetricsHandle`] for registering the global provider, accessing the Prometheus registry,
+//!   and shutting down the pipeline.
+//! - Declarative macros ([`global_meter!`], [`counter_metric!`], [`up_down_counter_metric!`],
+//!   [`gauge_metric!`], [`histogram_metric_f64!`], [`metric_attributes!`],
+//!   [`metric_attributes_vec!`]) for convenient instrument creation.
+//!
+//! # Features
+//!
+//! - `opentelemetry` - Enables the `opentelemetry` core crate dependency and the macros.
+//! - `opentelemetry-otlp` - Enables OTLP exporter support (implies `opentelemetry`).
+//!   - `opentelemetry-otlp-gzip` - Enables gzip compression for the OTLP gRPC transport.
+//!     Only effective when `opentelemetry-otlp` is also enabled.
+//!   - `opentelemetry-otlp-zstd` - Enables zstd compression for the OTLP gRPC transport.
+//!     Only effective when `opentelemetry-otlp` is also enabled.
+//! - `opentelemetry-prometheus` - Enables Prometheus exporter support and re-exports the
+//!   [`prometheus`] crate (implies `opentelemetry`).
+//! - `opentelemetry-internal-logs` - Enables internal diagnostic logging from the OpenTelemetry
+//!   crates. This only affects crates already activated by other features.
+//! - `opentelemetry-semantic-conventions` - Re-exports the [`opentelemetry_semantic_conventions`]
+//!   crate for standard OpenTelemetry attribute names.
+//!
+//! # Example
+//!
+//! ```toml
+//! [dependencies]
+//! metrics_utils = { version = "0.1", features = ["opentelemetry-otlp"] }
+//! ```
+//!
+//! ```
+//! # #[cfg(feature = "opentelemetry-otlp")]
+//! # #[tokio::main(flavor = "current_thread")]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use metrics_utils::{
+//!     MetricsConfig, OtlpConfig, counter_metric, global_meter, histogram_metric_f64,
+//!     init_metrics, metric_attributes,
+//! };
+//!
+//! // Configure the metrics pipeline
+//! let config = MetricsConfig {
+//!     service_name: String::from("my_service"),
+//!     resource_attributes: vec![
+//!         ("service.version".into(), "1.0.0".into()),
+//!         ("deployment.environment.name".into(), "production".into()),
+//!     ],
+//!     # #[cfg(feature = "opentelemetry-otlp")]
+//!     otlp_config: Some(OtlpConfig {
+//!         endpoint: "http://localhost:4317".into(),
+//!         endpoint_timeout: Some(std::time::Duration::from_secs(5)),
+//!         metrics_export_interval: Some(std::time::Duration::from_secs(10)),
+//!         # #[cfg(any(feature = "opentelemetry-otlp-gzip", feature = "opentelemetry-otlp-zstd"))]
+//!         compression: None,
+//!     }),
+//!     # #[cfg(feature = "opentelemetry-prometheus")]
+//!     enable_prometheus: false,
+//! };
+//!
+//! // Initialize the metrics pipeline and obtain a handle to it
+//! let handle = init_metrics(&config)?;
+//!
+//! // Register the provider as the global meter provider
+//! handle.register_as_global();
+//!
+//! // Create a meter for this service
+//! global_meter!(pub MY_METER, "my_service");
+//!
+//! // Create instruments
+//! counter_metric!(
+//!     pub REQUEST_COUNT, MY_METER,
+//!     name: "http.server.requests",
+//!     description: "Count of HTTP server requests processed",
+//! );
+//! histogram_metric_f64!(
+//!     pub REQUEST_DURATION, MY_METER,
+//!     name: "http.server.request.duration",
+//!     description: "Duration of HTTP server requests in seconds",
+//!     unit: "s",
+//! );
+//!
+//! // In your request handler:
+//!
+//! // Record the measurements
+//! REQUEST_COUNT.add(1, metric_attributes!(("http.route", "/health")));
+//! REQUEST_DURATION.record(0.123, metric_attributes!(("http.route", "/health")));
+//!
+//! // Shut down the provider to flush any pending exports, when shutting down your application
+//! if let Err(e) = handle.shutdown() {
+//!     eprintln!("Metrics provider shutdown failed: {e}");
+//! }
+//!
+//! # Ok(())
+//! # }
+//! # #[cfg(not(feature = "opentelemetry-otlp"))]
+//! # fn main() {}
+//! ```
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(test(attr(deny(warnings))))]
+
+// Public so that declarative macros can reference re-exported OpenTelemetry types across crate
+// boundaries.
+// Doc-hidden because consumers should import items via re-exports below.
+#[cfg(feature = "opentelemetry")]
+#[doc(hidden)]
+pub mod opentelemetry;
+mod utils;
+
+#[cfg(feature = "opentelemetry-semantic-conventions")]
+pub use opentelemetry_semantic_conventions;
+#[cfg(feature = "opentelemetry-prometheus")]
+pub use prometheus;
+
+#[cfg(all(
+    feature = "opentelemetry-otlp",
+    any(
+        feature = "opentelemetry-otlp-gzip",
+        feature = "opentelemetry-otlp-zstd"
+    )
+))]
+pub use self::opentelemetry::OtlpCompression;
+#[cfg(feature = "opentelemetry-otlp")]
+pub use self::opentelemetry::OtlpConfig;
+#[cfg(feature = "opentelemetry")]
+pub use self::opentelemetry::{MetricsConfig, MetricsError};
+#[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+pub use self::opentelemetry::{MetricsHandle, init_metrics};
+pub use self::utils::f64_histogram_buckets;

--- a/crates/metrics_utils/src/opentelemetry.rs
+++ b/crates/metrics_utils/src/opentelemetry.rs
@@ -1,0 +1,600 @@
+//! OpenTelemetry-backed metrics infrastructure.
+//!
+//! This module is only available when the `opentelemetry` feature is enabled.
+
+mod macros;
+
+// Re-export the OpenTelemetry types referenced by the macros in the `macros` module.
+#[doc(hidden)]
+pub use ::opentelemetry::{
+    KeyValue, Value, global,
+    metrics::{Counter, Gauge, Histogram, Meter, UpDownCounter},
+};
+
+/// Configuration for the metrics system.
+#[derive(Debug, Clone)]
+pub struct MetricsConfig {
+    /// The service name to report as the `service.name` [`Resource`][opentelemetry_sdk::Resource]
+    /// attribute.
+    pub service_name: String,
+
+    /// Additional [`Resource`][opentelemetry_sdk::Resource] attributes,
+    /// provided as `(key, value)` pairs.
+    ///
+    /// These are merged with the environment-detected resource attributes and the
+    /// telemetry SDK-provided attributes.
+    /// Keys should follow the
+    /// [OpenTelemetry semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md)
+    /// (e.g. `service.version`, `deployment.environment.name`).
+    pub resource_attributes: Vec<(String, String)>,
+
+    /// Configuration for the OTLP push metrics exporter.
+    #[cfg(feature = "opentelemetry-otlp")]
+    pub otlp_config: Option<OtlpConfig>,
+
+    /// Whether to enable the Prometheus pull exporter.
+    #[cfg(feature = "opentelemetry-prometheus")]
+    pub enable_prometheus: bool,
+}
+
+/// Configuration for the OTLP push metrics exporter.
+#[cfg(feature = "opentelemetry-otlp")]
+#[derive(Debug, Clone)]
+pub struct OtlpConfig {
+    /// The OTLP collector endpoint (e.g. `http://localhost:4317`).
+    pub endpoint: String,
+
+    /// Timeout applied to each OTLP metrics export.
+    ///
+    /// If not specified, the [`MetricExporter`][opentelemetry_otlp::MetricExporter]'s
+    /// default timeout is used.
+    pub endpoint_timeout: Option<std::time::Duration>,
+
+    /// Time between consecutive metrics exports.
+    ///
+    /// If not specified, the [`PeriodicReader`][opentelemetry_sdk::metrics::PeriodicReader]'s
+    /// default interval is used.
+    pub metrics_export_interval: Option<std::time::Duration>,
+
+    /// Compression algorithm for gRPC requests.
+    #[cfg(any(
+        feature = "opentelemetry-otlp-gzip",
+        feature = "opentelemetry-otlp-zstd"
+    ))]
+    pub compression: Option<OtlpCompression>,
+}
+
+/// Compression algorithm for the OTLP gRPC exporter.
+/// Each variant requires the corresponding feature flag.
+#[cfg(all(
+    feature = "opentelemetry-otlp",
+    any(
+        feature = "opentelemetry-otlp-gzip",
+        feature = "opentelemetry-otlp-zstd"
+    )
+))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OtlpCompression {
+    /// Compress data using gzip.
+    #[cfg(feature = "opentelemetry-otlp-gzip")]
+    Gzip,
+
+    /// Compress data using zstd.
+    #[cfg(feature = "opentelemetry-otlp-zstd")]
+    Zstd,
+}
+
+#[cfg(all(
+    feature = "opentelemetry-otlp",
+    any(
+        feature = "opentelemetry-otlp-gzip",
+        feature = "opentelemetry-otlp-zstd"
+    )
+))]
+impl OtlpCompression {
+    /// Converts to the corresponding [`opentelemetry_otlp::Compression`] variant.
+    fn as_otel(self) -> opentelemetry_otlp::Compression {
+        match self {
+            #[cfg(feature = "opentelemetry-otlp-gzip")]
+            Self::Gzip => opentelemetry_otlp::Compression::Gzip,
+
+            #[cfg(feature = "opentelemetry-otlp-zstd")]
+            Self::Zstd => opentelemetry_otlp::Compression::Zstd,
+        }
+    }
+}
+
+impl MetricsConfig {
+    /// Validates the configuration, returning an error if any values are invalid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetricsError::InvalidConfig`] if any configuration value is invalid.
+    pub fn validate(&self) -> Result<(), MetricsError> {
+        if self.service_name.is_empty() {
+            return Err(MetricsError::InvalidConfig(
+                "service name must not be empty",
+            ));
+        }
+
+        #[cfg(feature = "opentelemetry-otlp")]
+        if let Some(otlp) = &self.otlp_config {
+            if otlp.endpoint.is_empty() {
+                return Err(MetricsError::InvalidConfig(
+                    "OTLP endpoint must not be empty",
+                ));
+            }
+
+            if let Some(timeout) = otlp.endpoint_timeout
+                && timeout.is_zero()
+            {
+                return Err(MetricsError::InvalidConfig(
+                    "OTLP endpoint timeout must be non-zero",
+                ));
+            }
+
+            if let Some(interval) = otlp.metrics_export_interval
+                && interval.is_zero()
+            {
+                return Err(MetricsError::InvalidConfig(
+                    "OTLP export interval must be non-zero",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Initializes the OpenTelemetry metrics pipeline based on the provided [`MetricsConfig`].
+///
+/// Builds an [`SdkMeterProvider`](opentelemetry_sdk::metrics::SdkMeterProvider) with a single
+/// [`Resource`](opentelemetry_sdk::Resource) and one
+/// [`MetricReader`](opentelemetry_sdk::metrics::reader::MetricReader) per configured exporter.
+/// When both OTLP and Prometheus exports are enabled, both readers are attached to the same
+/// provider.
+/// Returns a [`MetricsHandle`] that can be used to register the provider globally,
+/// access the Prometheus registry, and shut the provider down.
+///
+/// This function does NOT set the global meter provider.
+/// Per the OpenTelemetry docs, setting the global meter provider is the application's
+/// responsibility.
+/// Use [`MetricsHandle::register_as_global`] as a convenience method for that, or call
+/// [`opentelemetry::global::set_meter_provider`] directly.
+///
+/// # Errors
+///
+/// This function returns:
+///
+/// - [`MetricsError::InvalidConfig`] if the configuration is invalid.
+/// - [`MetricsError::NoExportersConfigured`] if no readers were attached (OTLP config is `None`
+///   and `enable_prometheus` is `false`).
+/// - Exporter-specific errors if an exporter cannot be built.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use metrics_utils::{MetricsConfig, OtlpConfig, init_metrics};
+///
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Configure metrics
+/// let config = MetricsConfig {
+///     service_name: String::from("my_service"),
+///     resource_attributes: vec![
+///         ("service.version".into(), "1.0.0".into()),
+///         ("deployment.environment.name".into(), "production".into()),
+///     ],
+///     # #[cfg(feature = "opentelemetry-otlp")]
+///     otlp_config: Some(OtlpConfig {
+///         endpoint: "http://localhost:4317".into(),
+///         endpoint_timeout: Some(Duration::from_secs(5)),
+///         metrics_export_interval: Some(Duration::from_secs(10)),
+///         # #[cfg(any(feature = "opentelemetry-otlp-gzip", feature = "opentelemetry-otlp-zstd"))]
+///         compression: None,
+///     }),
+///     # #[cfg(feature = "opentelemetry-prometheus")]
+///     enable_prometheus: true,
+/// };
+///
+/// // Initialize metrics and register global meter provider
+/// let handle = init_metrics(&config)?;
+/// handle.register_as_global();
+///
+/// # #[cfg(feature = "opentelemetry-prometheus")]
+/// if let Some(_registry) = handle.prometheus_registry() {
+///     // Serve registry at `/metrics` endpoint.
+/// }
+///
+/// // Shutdown provider when shutting down your application
+/// handle.shutdown()?;
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+pub fn init_metrics(config: &MetricsConfig) -> Result<MetricsHandle, MetricsError> {
+    config.validate()?;
+
+    let resource = build_resource(config);
+    let mut provider_builder =
+        opentelemetry_sdk::metrics::SdkMeterProvider::builder().with_resource(resource);
+
+    let mut has_reader = false;
+
+    #[cfg(feature = "opentelemetry-otlp")]
+    if let Some(otlp_config) = &config.otlp_config {
+        provider_builder = provider_builder.with_reader(build_otlp_reader(otlp_config)?);
+        has_reader = true;
+    }
+
+    #[cfg(feature = "opentelemetry-prometheus")]
+    let prometheus_registry = if config.enable_prometheus {
+        let (registry, exporter) = build_prometheus_exporter()?;
+        provider_builder = provider_builder.with_reader(exporter);
+        has_reader = true;
+        Some(registry)
+    } else {
+        None
+    };
+
+    if !has_reader {
+        return Err(MetricsError::NoExportersConfigured);
+    }
+
+    let provider = provider_builder.build();
+
+    Ok(MetricsHandle {
+        provider,
+        #[cfg(feature = "opentelemetry-prometheus")]
+        prometheus_registry,
+    })
+}
+
+/// Build the [`Resource`][opentelemetry_sdk::Resource] from config, layering `service.name` and
+/// extra attributes on top of the environment-detected resource attributes and
+/// telemetry SDK-provided attributes.
+#[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+fn build_resource(config: &MetricsConfig) -> opentelemetry_sdk::Resource {
+    opentelemetry_sdk::Resource::builder()
+        .with_service_name(config.service_name.clone())
+        .with_attributes(
+            config
+                .resource_attributes
+                .iter()
+                .map(|(key, value)| KeyValue::new(key.clone(), value.clone())),
+        )
+        .build()
+}
+
+/// Build a [`PeriodicReader`][opentelemetry_sdk::metrics::PeriodicReader] wrapping a
+/// [`MetricExporter`][opentelemetry_otlp::MetricExporter].
+#[cfg(feature = "opentelemetry-otlp")]
+fn build_otlp_reader(
+    config: &OtlpConfig,
+) -> Result<
+    opentelemetry_sdk::metrics::PeriodicReader<opentelemetry_otlp::MetricExporter>,
+    MetricsError,
+> {
+    use opentelemetry_otlp::WithExportConfig;
+    #[cfg(any(
+        feature = "opentelemetry-otlp-gzip",
+        feature = "opentelemetry-otlp-zstd"
+    ))]
+    use opentelemetry_otlp::WithTonicConfig;
+
+    let mut exporter_builder = opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint(&config.endpoint);
+
+    #[cfg(any(
+        feature = "opentelemetry-otlp-gzip",
+        feature = "opentelemetry-otlp-zstd"
+    ))]
+    if let Some(compression) = config.compression {
+        exporter_builder = exporter_builder.with_compression(compression.as_otel());
+    }
+
+    if let Some(timeout) = config.endpoint_timeout {
+        exporter_builder = exporter_builder.with_timeout(timeout);
+    }
+
+    let exporter = exporter_builder
+        .build()
+        .map_err(|error| MetricsError::OtlpExporterBuild {
+            source: Box::new(error),
+        })?;
+
+    let mut reader_builder = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter);
+
+    if let Some(interval) = config.metrics_export_interval {
+        reader_builder = reader_builder.with_interval(interval);
+    }
+
+    Ok(reader_builder.build())
+}
+
+/// Build a Prometheus exporter and return the [`Registry`][prometheus::Registry] and
+/// [`PrometheusExporter`][opentelemetry_prometheus::PrometheusExporter].
+#[cfg(feature = "opentelemetry-prometheus")]
+fn build_prometheus_exporter() -> Result<
+    (
+        prometheus::Registry,
+        opentelemetry_prometheus::PrometheusExporter,
+    ),
+    MetricsError,
+> {
+    let registry = prometheus::Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()
+        .map_err(|error| MetricsError::PrometheusExporterBuild {
+            source: Box::new(error),
+        })?;
+    Ok((registry, exporter))
+}
+
+/// A handle to the initialized metrics pipeline.
+///
+/// Can be used to register the provider as the global meter provider, access the Prometheus
+/// registry (when configured), and shut the provider down.
+///
+/// # Global provider registration
+///
+/// The built provider is NOT automatically set as the global meter provider by [`init_metrics`].
+/// Call [`register_as_global`][Self::register_as_global] to do so, or call
+/// [`opentelemetry::global::set_meter_provider`] directly.
+/// Until the global provider is set, meters and instruments created via the
+/// [`global_meter!`][crate::global_meter!] macro and other instrumentation macros are no-ops,
+/// and recorded measurements are discarded.
+///
+/// # Shutdown
+///
+/// The provider is shut down when [`shutdown`][Self::shutdown] is called or when the handle is
+/// dropped.
+/// Calling [`shutdown`][Self::shutdown] after the provider has already been shut down returns
+/// an error.
+/// Dropping the handle after an explicit shutdown is a no-op.
+#[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+#[derive(Debug)]
+pub struct MetricsHandle {
+    /// The SDK meter provider managing the pipeline.
+    provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+
+    /// The Prometheus registry.
+    #[cfg(feature = "opentelemetry-prometheus")]
+    prometheus_registry: Option<prometheus::Registry>,
+}
+
+#[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+impl MetricsHandle {
+    /// Registers the underlying meter provider as the global meter provider.
+    ///
+    /// This is a convenience wrapper around [`opentelemetry::global::set_meter_provider`].
+    /// Until this is called (or the application sets the global provider itself), meters and
+    /// instruments created via the [`global_meter!`](crate::global_meter!) macro and other
+    /// instrumentation macros are no-ops, and recorded measurements are discarded.
+    pub fn register_as_global(&self) {
+        global::set_meter_provider(self.provider.clone());
+    }
+
+    /// Returns a reference to the Prometheus registry, if available.
+    ///
+    /// The consumer is responsible for serving the registry over HTTP (e.g. at `/metrics`).
+    #[cfg(feature = "opentelemetry-prometheus")]
+    pub fn prometheus_registry(&self) -> Option<&prometheus::Registry> {
+        self.prometheus_registry.as_ref()
+    }
+
+    /// Shuts down the meter provider, flushing any buffered metrics and releasing resources.
+    ///
+    /// Calling [`shutdown`][Self::shutdown] after the provider has already been shut down returns
+    /// an error.
+    /// Dropping the handle after an explicit shutdown is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetricsError::Shutdown`] if the provider could not be shut down (e.g. a flush or
+    /// release step failed), or if shutdown was already invoked.
+    pub fn shutdown(&self) -> Result<(), MetricsError> {
+        self.provider
+            .shutdown()
+            .map_err(|error| MetricsError::Shutdown {
+                source: Box::new(error),
+            })
+    }
+}
+
+#[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+impl Drop for MetricsHandle {
+    fn drop(&mut self) {
+        if let Err(error) = self.provider.shutdown() {
+            tracing::error!("failed to shutdown metric provider during drop: {error}");
+        }
+    }
+}
+
+/// Errors that can occur during metrics initialization and shutdown.
+#[cfg_attr(
+    not(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus")),
+    expect(
+        missing_copy_implementations,
+        reason = "No need for this error type to implement `Copy`"
+    )
+)]
+#[derive(Debug, thiserror::Error)]
+pub enum MetricsError {
+    /// The configuration is invalid.
+    #[error("invalid metrics configuration: {0}")]
+    InvalidConfig(&'static str),
+
+    /// No exporters were enabled or configured.
+    #[error("no exporters configured: enable at least one of OTLP or Prometheus exporter")]
+    NoExportersConfigured,
+
+    /// The OTLP exporter could not be built.
+    #[cfg(feature = "opentelemetry-otlp")]
+    #[error("failed to build OTLP metric exporter")]
+    OtlpExporterBuild {
+        /// The underlying error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The Prometheus exporter could not be built.
+    #[cfg(feature = "opentelemetry-prometheus")]
+    #[error("failed to build Prometheus metric exporter")]
+    PrometheusExporterBuild {
+        /// The underlying error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The meter provider could not be shut down. This is returned by [`MetricsHandle::shutdown`].
+    #[cfg(any(feature = "opentelemetry-otlp", feature = "opentelemetry-prometheus"))]
+    #[error("failed to shutdown meter provider")]
+    Shutdown {
+        /// The underlying error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+#[cfg(all(
+    test,
+    feature = "opentelemetry-otlp",
+    feature = "opentelemetry-prometheus"
+))]
+mod tests {
+    use std::time::Duration;
+
+    use super::{MetricsConfig, MetricsError, OtlpConfig, init_metrics};
+
+    #[test]
+    fn test_config_validation() {
+        // Enable OTLP exporter only
+        let config = MetricsConfig {
+            service_name: String::from("test_service"),
+            resource_attributes: Vec::new(),
+            otlp_config: Some(OtlpConfig {
+                endpoint: "http://localhost:4317".into(),
+                endpoint_timeout: None,
+                metrics_export_interval: None,
+                #[cfg(any(
+                    feature = "opentelemetry-otlp-gzip",
+                    feature = "opentelemetry-otlp-zstd"
+                ))]
+                compression: None,
+            }),
+            enable_prometheus: false,
+        };
+        assert!(config.validate().is_ok());
+
+        // Enable both OTLP and Prometheus exporters
+        let config = MetricsConfig {
+            service_name: String::from("test_service"),
+            resource_attributes: vec![("env".into(), "test".into())],
+            otlp_config: Some(OtlpConfig {
+                endpoint: "http://localhost:4317".into(),
+                endpoint_timeout: Some(Duration::from_secs(5)),
+                metrics_export_interval: Some(Duration::from_secs(10)),
+                #[cfg(any(
+                    feature = "opentelemetry-otlp-gzip",
+                    feature = "opentelemetry-otlp-zstd"
+                ))]
+                compression: None,
+            }),
+            enable_prometheus: true,
+        };
+        assert!(config.validate().is_ok());
+
+        // Empty service name
+        let config = MetricsConfig {
+            service_name: String::new(),
+            resource_attributes: Vec::new(),
+            otlp_config: None,
+            enable_prometheus: false,
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(MetricsError::InvalidConfig(_))
+        ));
+
+        // Empty OTLP endpoint
+        let config = MetricsConfig {
+            service_name: String::from("test"),
+            resource_attributes: Vec::new(),
+            otlp_config: Some(OtlpConfig {
+                endpoint: String::new(),
+                endpoint_timeout: None,
+                metrics_export_interval: None,
+                #[cfg(any(
+                    feature = "opentelemetry-otlp-gzip",
+                    feature = "opentelemetry-otlp-zstd"
+                ))]
+                compression: None,
+            }),
+            enable_prometheus: false,
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(MetricsError::InvalidConfig(_))
+        ));
+
+        // Zero OTLP timeout
+        let config = MetricsConfig {
+            service_name: String::from("test"),
+            resource_attributes: Vec::new(),
+            otlp_config: Some(OtlpConfig {
+                endpoint: "http://localhost:4317".into(),
+                endpoint_timeout: Some(Duration::ZERO),
+                metrics_export_interval: None,
+                #[cfg(any(
+                    feature = "opentelemetry-otlp-gzip",
+                    feature = "opentelemetry-otlp-zstd"
+                ))]
+                compression: None,
+            }),
+            enable_prometheus: false,
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(MetricsError::InvalidConfig(_))
+        ));
+
+        // Zero OTLP export interval
+        let config = MetricsConfig {
+            service_name: String::from("test"),
+            resource_attributes: Vec::new(),
+            otlp_config: Some(OtlpConfig {
+                endpoint: "http://localhost:4317".into(),
+                endpoint_timeout: None,
+                metrics_export_interval: Some(Duration::ZERO),
+                #[cfg(any(
+                    feature = "opentelemetry-otlp-gzip",
+                    feature = "opentelemetry-otlp-zstd"
+                ))]
+                compression: None,
+            }),
+            enable_prometheus: false,
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(MetricsError::InvalidConfig(_))
+        ));
+    }
+
+    #[test]
+    fn init_with_no_exporters_returns_error() {
+        let config = MetricsConfig {
+            service_name: String::from("test_service"),
+            resource_attributes: Vec::new(),
+            otlp_config: None,
+            enable_prometheus: false,
+        };
+
+        let error = init_metrics(&config).unwrap_err();
+        assert!(matches!(error, MetricsError::NoExportersConfigured));
+    }
+}

--- a/crates/metrics_utils/src/opentelemetry/macros.rs
+++ b/crates/metrics_utils/src/opentelemetry/macros.rs
@@ -1,0 +1,433 @@
+/// Create a global [`Meter`][opentelemetry::metrics::Meter] with the specified name.
+///
+/// The meter is obtained from the global meter provider.
+/// Until the application sets the global provider
+/// (via [`MetricsHandle::register_as_global`][crate::MetricsHandle::register_as_global]
+/// or [`opentelemetry::global::set_meter_provider`]), the meter and any instruments created from
+/// it are no-ops, and recorded measurements are discarded.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::global_meter;
+///
+/// global_meter!(pub FOO_METER, "foo");
+/// global_meter!(pub BAR_METER);
+/// ```
+#[macro_export]
+macro_rules! global_meter {
+    // Explicit meter name.
+    ($vis:vis $meter:ident, $name:literal) => {
+        $vis static $meter: ::std::sync::LazyLock<
+            $crate::opentelemetry::Meter
+        > = ::std::sync::LazyLock::new(|| {
+            $crate::opentelemetry::global::meter($name)
+        });
+    };
+
+    // Meter name derived from the identifier.
+    ($vis:vis $meter:ident) => {
+        $vis static $meter: ::std::sync::LazyLock<
+            $crate::opentelemetry::Meter
+        > = ::std::sync::LazyLock::new(|| {
+            $crate::opentelemetry::global::meter(
+                ::std::stringify!($meter),
+            )
+        });
+    };
+}
+
+/// Create a [`Counter<u64>`][opentelemetry::metrics::Counter] with the given name.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::{counter_metric, global_meter};
+///
+/// global_meter!(pub MY_METER, "my_service");
+///
+/// counter_metric!(
+///     pub REQUEST_COUNT, MY_METER,
+///     name: "request.count",
+///     description: "Number of incoming requests",
+/// );
+/// ```
+#[macro_export]
+macro_rules! counter_metric {
+    // Entry arm: capture all keyword arguments and start the builder chain.
+    // The metric name defaults to the Rust identifier (stringified).
+    // Remaining tokens (`$rest`) are passed to the recursive builder which processes
+    // `name:` (must appear first if provided), then `description:`, `unit:` in any order,
+    // each transforming the builder expression, until no tokens remain and the final `static`
+    // binding is emitted.
+    ($vis:vis $name:ident, $meter:ident $($rest:tt)*) => {
+        $crate::__build_counter_metric! { $vis $name, $meter [$($rest)*]
+            $meter.u64_counter(::std::stringify!($name)) }
+    };
+}
+
+/// Internal build helper for [`counter_metric!`].
+///
+/// Walks the keyword token stream (`name:`, `description:`, `unit:`, commas) one token at a time,
+/// threading the instrument builder expression through recursion, and emits the final `static`
+/// binding in the base case.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __build_counter_metric {
+    // `name:` overrides the default metric name derived from the identifier.
+    ($vis:vis $name:ident, $meter:ident
+        [name: $metric_name:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_counter_metric! { $vis $name, $meter [$($rest)*]
+            $meter.u64_counter($metric_name) }
+    };
+
+    // `description:` attaches a human-readable description to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [description: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_counter_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_description($v) }
+    };
+
+    // `unit:` attaches the unit of measurement to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [unit: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_counter_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_unit($v) }
+    };
+
+    // Comma skimmer: strips a leading comma so the next keyword can match.
+    ($vis:vis $name:ident, $meter:ident
+        [, $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_counter_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* }
+    };
+
+    // Token stream exhausted, emit the final `static` counter binding.
+    ($vis:vis $name:ident, $meter:ident [] $($expr:tt)*) => {
+        $vis static $name: ::std::sync::LazyLock<
+            $crate::opentelemetry::Counter<u64>
+        > = ::std::sync::LazyLock::new(|| { $($expr)* .build() });
+    };
+}
+
+/// Create an [`UpDownCounter<i64>`][opentelemetry::metrics::UpDownCounter] with the given name.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::{up_down_counter_metric, global_meter};
+///
+/// global_meter!(pub MY_METER, "my_service");
+///
+/// up_down_counter_metric!(
+///     pub ACTIVE_CONNECTIONS, MY_METER,
+///     name: "active.connections",
+///     description: "Number of active connections",
+/// );
+/// ```
+#[macro_export]
+macro_rules! up_down_counter_metric {
+    // Entry arm: capture all keyword arguments and start the builder chain.
+    // Remaining tokens (`$rest`) are passed to the recursive builder which processes
+    // `name:` (must appear first if provided), then `description:`, `unit:` in any order,
+    // each transforming the builder expression, until no tokens remain and the final `static`
+    // binding is emitted.
+    ($vis:vis $name:ident, $meter:ident $($rest:tt)*) => {
+        $crate::__build_up_down_counter_metric! { $vis $name, $meter [$($rest)*]
+            $meter.i64_up_down_counter(::std::stringify!($name)) }
+    };
+}
+
+/// Internal build helper for [`up_down_counter_metric!`].
+///
+/// Walks the keyword token stream (`name:`, `description:`, `unit:`, commas) one token at a time,
+/// threading the instrument builder expression through recursion, and emits the final `static`
+/// binding in the base case.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __build_up_down_counter_metric {
+    // `name:` overrides the default metric name derived from the identifier.
+    ($vis:vis $name:ident, $meter:ident
+        [name: $metric_name:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_up_down_counter_metric! { $vis $name, $meter [$($rest)*]
+            $meter.i64_up_down_counter($metric_name) }
+    };
+
+    // `description:` attaches a human-readable description to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [description: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_up_down_counter_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_description($v) }
+    };
+
+    // `unit:` attaches the unit of measurement to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [unit: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_up_down_counter_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_unit($v) }
+    };
+
+    // Comma skimmer: strips a leading comma so the next keyword can match.
+    ($vis:vis $name:ident, $meter:ident
+        [, $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_up_down_counter_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* }
+    };
+
+    // Token stream exhausted, emit the final `static` up-down counter binding.
+    ($vis:vis $name:ident, $meter:ident [] $($expr:tt)*) => {
+        $vis static $name: ::std::sync::LazyLock<
+            $crate::opentelemetry::UpDownCounter<i64>
+        > = ::std::sync::LazyLock::new(|| { $($expr)* .build() });
+    };
+}
+
+/// Create a [`Gauge<u64>`][opentelemetry::metrics::Gauge] with the given name.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::{gauge_metric, global_meter};
+///
+/// global_meter!(pub MY_METER, "my_service");
+///
+/// gauge_metric!(
+///     pub CPU_TEMPERATURE, MY_METER,
+///     name: "cpu.temperature",
+///     description: "Current CPU temperature",
+///     unit: "Cel",
+/// );
+/// ```
+#[macro_export]
+macro_rules! gauge_metric {
+    // Entry arm: capture all keyword arguments and start the builder chain.
+    // The metric name defaults to the Rust identifier (stringified).
+    // Remaining tokens (`$rest`) are passed to the recursive builder which processes
+    // `name:` (must appear first if provided), then `description:`, `unit:` in any order,
+    // each transforming the builder expression, until no tokens remain and the final `static`
+    // binding is emitted.
+    ($vis:vis $name:ident, $meter:ident $($rest:tt)*) => {
+        $crate::__build_gauge_metric! { $vis $name, $meter [$($rest)*]
+            $meter.u64_gauge(::std::stringify!($name)) }
+    };
+}
+
+/// Internal build helper for [`gauge_metric!`].
+///
+/// Walks the keyword token stream (`name:`, `description:`, `unit:`, commas) one token at a time,
+/// threading the instrument builder expression through recursion, and emits the final `static`
+/// binding in the base case.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __build_gauge_metric {
+    // `name:` overrides the default metric name derived from the identifier.
+    ($vis:vis $name:ident, $meter:ident
+        [name: $metric_name:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_gauge_metric! { $vis $name, $meter [$($rest)*]
+            $meter.u64_gauge($metric_name) }
+    };
+
+    // `description:` attaches a human-readable description to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [description: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_gauge_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_description($v) }
+    };
+
+    // `unit:` attaches the unit of measurement to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [unit: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_gauge_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_unit($v) }
+    };
+
+    // Comma skimmer: strips a leading comma so the next keyword can match.
+    ($vis:vis $name:ident, $meter:ident
+        [, $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_gauge_metric! { $vis $name, $meter [$($rest)*]
+            $($expr)* }
+    };
+
+    // Token stream exhausted, emit the final `static` gauge binding.
+    ($vis:vis $name:ident, $meter:ident [] $($expr:tt)*) => {
+        $vis static $name: ::std::sync::LazyLock<
+            $crate::opentelemetry::Gauge<u64>
+        > = ::std::sync::LazyLock::new(|| { $($expr)* .build() });
+    };
+}
+
+/// Create a [`Histogram<f64>`][opentelemetry::metrics::Histogram] with the given name.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::{histogram_metric_f64, global_meter, f64_histogram_buckets};
+///
+/// global_meter!(pub MY_METER, "my_service");
+///
+/// histogram_metric_f64!(
+///     pub REQUEST_DURATION, MY_METER,
+///     name: "request.duration",
+///     description: "Request duration in seconds",
+///     unit: "s",
+///     buckets: f64_histogram_buckets().to_vec(),
+/// );
+/// ```
+#[macro_export]
+macro_rules! histogram_metric_f64 {
+    // Entry arm: capture all keyword arguments and start the builder chain.
+    // The metric name defaults to the Rust identifier (stringified).
+    // Remaining tokens (`$rest`) are passed to the recursive builder which processes
+    // `name:` (must appear first if provided), then `description:`, `unit:`, `buckets:` in any
+    // order, each transforming the builder expression, until no tokens remain and the final
+    // `static` binding is emitted.
+    ($vis:vis $name:ident, $meter:ident $($rest:tt)*) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter [$($rest)*]
+            $meter.f64_histogram(::std::stringify!($name)) }
+    };
+}
+
+/// Internal build helper for [`histogram_metric_f64!`].
+///
+/// Walks the keyword token stream (`name:`, `description:`, `unit:`, `buckets:`, commas) one token
+/// at a time, threading the instrument builder expression through recursion, and emits the final
+/// `static` binding in the base case.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __build_histogram_metric_f64 {
+    // `name:` overrides the default metric name derived from the identifier.
+    ($vis:vis $name:ident, $meter:ident
+        [name: $metric_name:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter [$($rest)*]
+            $meter.f64_histogram($metric_name) }
+    };
+
+    // `description:` attaches a human-readable description to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [description: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_description($v) }
+    };
+
+    // `unit:` attaches the unit of measurement to the instrument.
+    ($vis:vis $name:ident, $meter:ident
+        [unit: $v:literal $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_unit($v) }
+    };
+
+    // `buckets:` as the last keyword: no trailing comma, so drain the token stream.
+    ($vis:vis $name:ident, $meter:ident
+        [buckets: $v:expr]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter []
+            $($expr)* .with_boundaries($v) }
+    };
+
+    // `buckets:` with more keywords following: consume the buckets value and continue.
+    ($vis:vis $name:ident, $meter:ident
+        [buckets: $v:expr, $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter [$($rest)*]
+            $($expr)* .with_boundaries($v) }
+    };
+
+    // Comma skimmer: strips a leading comma so the next keyword can match.
+    ($vis:vis $name:ident, $meter:ident
+        [, $($rest:tt)*]
+        $($expr:tt)*
+    ) => {
+        $crate::__build_histogram_metric_f64! { $vis $name, $meter [$($rest)*]
+            $($expr)* }
+    };
+
+    // Token stream exhausted, emit the final `static` histogram binding.
+    ($vis:vis $name:ident, $meter:ident [] $($expr:tt)*) => {
+        $vis static $name: ::std::sync::LazyLock<
+            $crate::opentelemetry::Histogram<f64>
+        > = ::std::sync::LazyLock::new(|| { $($expr)* .build() });
+    };
+}
+
+/// Create a [`&[KeyValue]`][opentelemetry::KeyValue] array from key-value pairs.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::metric_attributes;
+///
+/// let attrs = metric_attributes!(("method", "GET"), ("status", "200"));
+/// assert_eq!(attrs.len(), 2);
+/// ```
+#[macro_export]
+macro_rules! metric_attributes {
+    ($(($key:expr, $value:expr $(,)?)),+ $(,)?) => {
+        &[$(
+            $crate::opentelemetry::KeyValue::new($key, $value)
+        ),+]
+    };
+}
+
+/// Builds an owned [`Vec<KeyValue>`][opentelemetry::KeyValue] for cases where attributes need to
+/// be extended dynamically.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::metric_attributes_vec;
+///
+/// let attrs = metric_attributes_vec!(("method", "GET"));
+/// assert_eq!(attrs.len(), 1);
+/// ```
+///
+/// Combine with `metric_attributes!` using `extend_from_slice`:
+///
+/// ```
+/// use metrics_utils::{metric_attributes, metric_attributes_vec};
+///
+/// let mut attrs = metric_attributes_vec!(("method", "GET"));
+/// attrs.extend_from_slice(metric_attributes!(("status", "200")));
+/// assert_eq!(attrs.len(), 2);
+/// ```
+#[macro_export]
+macro_rules! metric_attributes_vec {
+    ($(($key:expr, $value:expr $(,)?)),+ $(,)?) => {
+        vec![
+            $(
+                $crate::opentelemetry::KeyValue::new($key, $value)
+            ),+
+        ]
+    };
+}

--- a/crates/metrics_utils/src/utils.rs
+++ b/crates/metrics_utils/src/utils.rs
@@ -1,0 +1,66 @@
+/// Returns a sensible set of default histogram bucket boundaries for f64 histograms.
+///
+/// Buckets start at `0.000_001` and double 29 times, yielding 30 boundaries.
+///
+/// # Example
+///
+/// ```
+/// use metrics_utils::f64_histogram_buckets;
+///
+/// let buckets = f64_histogram_buckets();
+/// assert_eq!(buckets[0], 0.000_001);
+/// assert_eq!(buckets.len(), 30);
+/// ```
+///
+/// Consumers may convert to owned buckets if needed:
+///
+/// ```
+/// use metrics_utils::f64_histogram_buckets;
+///
+/// let owned: Vec<f64> = f64_histogram_buckets().to_vec();
+/// assert_eq!(owned.len(), 30);
+/// ```
+#[inline]
+pub const fn f64_histogram_buckets() -> &'static [f64] {
+    const NUM_BOUNDARIES: usize = 30;
+
+    const BUCKETS: [f64; NUM_BOUNDARIES] = {
+        let mut buckets = [0.0f64; NUM_BOUNDARIES];
+        let mut index = 0;
+        let mut value = 0.000_001;
+
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "Array index guarded by loop condition `index < NUM_BOUNDARIES`; \
+                array length equals the same const"
+        )]
+        while index < NUM_BOUNDARIES {
+            buckets[index] = value;
+            value = value * 2.0;
+            index += 1;
+        }
+
+        buckets
+    };
+
+    &BUCKETS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buckets_are_monotonically_increasing() {
+        let buckets = f64_histogram_buckets();
+        for i in 1..buckets.len() {
+            assert!(
+                buckets[i] > buckets[i - 1],
+                "buckets[{i}] = {} <= buckets[{}] = {}",
+                buckets[i],
+                i - 1,
+                buckets[i - 1]
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new `metrics_utils` crate for configuring and managing OpenTelemetry metrics pipelines in Rust applications without requiring consumers to add the OpenTelemetry SDK crates as direct dependencies. The crate supports OTLP metrics export over gRPC and Prometheus pull-based metrics export, each gated behind its corresponding feature flag.

This PR includes the following changes:

- Introduces `MetricsConfig` as the entry point for configuring a metrics pipeline.
- Provides `init_metrics()` for constructing the configured meter provider, readers, and exporters.
- Introduces `MetricsHandle` for managing the pipeline lifecycle, including registering the global meter provider, accessing the Prometheus registry when configured, and shutting down the pipeline while flushing pending exports.
- Provides macros for declaring meters, metric instruments, and metric attributes.
- Introduces `f64_histogram_buckets()` with a reusable set of default bucket boundaries for `f64` histograms.