### PR TITLE
Add structured serde JSON log field wrapper

### DIFF
--- a/crates/log_utils/src/lib.rs
+++ b/crates/log_utils/src/lib.rs
@@ -108,5 +108,5 @@ pub use self::tracing::{
     AdditionalFieldsPlacement, ConsoleLogFormat, ConsoleLoggingConfig, DirectivePrintTarget,
     FileLoggingConfig, JsonFormattingLayer, JsonFormattingLayerConfig, Level, LoggerConfig,
     LoggerError, LoggingComponents, RecordType, Rotation, SpanStorageLayer,
-    build_logging_components,
+    build_logging_components, record_json,
 };

--- a/crates/log_utils/src/tracing.rs
+++ b/crates/log_utils/src/tracing.rs
@@ -17,6 +17,8 @@ pub use self::{
     storage::SpanStorageLayer,
 };
 
+pub use self::storage::record_json;
+
 mod keys {
     use std::sync::LazyLock;
 
@@ -602,6 +604,68 @@ mod tests {
 
         // Verify other fields are also present at top level (default placement)
         assert_eq!(log_entry["other_field"], "value");
+    }
+
+    #[test]
+    fn test_record_json_records_structured_json() {
+        let test_writer = TestWriter::new();
+
+        let config = JsonFormattingLayerConfig {
+            static_top_level_fields: HashMap::new(),
+            top_level_keys: HashSet::new(),
+            log_span_lifecycles: false,
+            additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+        };
+
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+        let formatting_layer = JsonFormattingLayer::new(
+            config,
+            test_writer.clone(),
+            serde_json::ser::CompactFormatter,
+        )
+        .unwrap();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(storage_layer)
+            .with(formatting_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = span!(
+                TracingLevel::INFO,
+                "connector_api_call",
+                api_message = tracing::field::Empty
+            );
+            let _guard = span.enter();
+
+            record_json(
+                "api_message",
+                json!({
+                    "request": {
+                        "method": "POST",
+                        "headers": {
+                            "content-type": "application/json"
+                        }
+                    },
+                    "response": {
+                        "status_code": 200
+                    }
+                }),
+            );
+
+            info!("Connector API call");
+        });
+
+        let output = test_writer.get_output();
+        let lines: Vec<&str> = output.trim().split('\n').collect();
+        let log_entry: Value = serde_json::from_str(lines[0]).unwrap();
+
+        assert!(log_entry["api_message"].is_object());
+        assert_eq!(log_entry["api_message"]["request"]["method"], "POST");
+        assert_eq!(
+            log_entry["api_message"]["request"]["headers"]["content-type"],
+            "application/json"
+        );
+        assert_eq!(log_entry["api_message"]["response"]["status_code"], 200);
     }
 
     #[test]

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -12,7 +12,28 @@ use tracing::{
     field::{Field, Visit},
     span::{Attributes, Record},
 };
-use tracing_subscriber::{Layer, layer::Context};
+use tracing_subscriber::{Layer, Registry, layer::Context, registry::LookupSpan};
+
+/// Records a JSON value on the current tracing span.
+///
+/// This is a stable extension point for structured JSON fields when the active subscriber uses
+/// [`SpanStorageLayer`].
+pub fn record_json(field: &'static str, value: serde_json::Value) {
+    let _ = tracing::Span::current().with_subscriber(|(id, dispatch)| {
+        let Some(registry) = dispatch.downcast_ref::<Registry>() else {
+            return;
+        };
+        let Some(span) = registry.span(id) else {
+            return;
+        };
+        let mut extensions = span.extensions_mut();
+        let Some(storage) = extensions.get_mut::<Storage<'_>>() else {
+            return;
+        };
+
+        storage.record_value(field, value);
+    });
+}
 
 /// A [`tracing_subscriber::Layer`] that enables storing key-value data within span extensions.
 /// It also handles propagation of "persistent" keys to parent spans and records span duration.
@@ -146,9 +167,7 @@ impl Visit for Storage<'_> {
     }
 }
 
-impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer<S>
-    for SpanStorageLayer
-{
+impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for SpanStorageLayer {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         #[expect(clippy::expect_used)]
         let span = ctx


### PR DESCRIPTION
## Summary
- add log_utils::SerdeValue for recording serde_json::Value fields as structured JSON
- preserve regular Debug field behavior as strings
- add a regression test covering nested JSON output

## Test
- cargo test -p log_utils --features tracing