### PR TITLE
feat(log_utils): add field_rename_map for runtime field name remapping

### DIFF
--- a/crates/log_utils/src/lib.rs
+++ b/crates/log_utils/src/lib.rs
@@ -71,6 +71,7 @@
 //!         print_filtering_directive: DirectivePrintTarget::Stdout,
 //!     }),
 //!     global_filtering_directive: Some("info".to_string()),
+//!     field_rename_map: HashMap::new(),
 //! };
 //!
 //! match build_logging_components(config) {

--- a/crates/log_utils/src/lib.rs
+++ b/crates/log_utils/src/lib.rs
@@ -108,5 +108,5 @@ pub use self::tracing::{
     AdditionalFieldsPlacement, ConsoleLogFormat, ConsoleLoggingConfig, DirectivePrintTarget,
     FileLoggingConfig, JsonFormattingLayer, JsonFormattingLayerConfig, Level, LoggerConfig,
     LoggerError, LoggingComponents, RecordType, Rotation, SpanStorageLayer,
-    build_logging_components,
+    build_logging_components, record_json,
 };

--- a/crates/log_utils/src/tracing.rs
+++ b/crates/log_utils/src/tracing.rs
@@ -17,6 +17,8 @@ pub use self::{
     storage::SpanStorageLayer,
 };
 
+pub use self::storage::record_json;
+
 mod keys {
     use std::sync::LazyLock;
 
@@ -602,6 +604,68 @@ mod tests {
 
         // Verify other fields are also present at top level (default placement)
         assert_eq!(log_entry["other_field"], "value");
+    }
+
+    #[test]
+    fn test_record_json_records_structured_json() {
+        let test_writer = TestWriter::new();
+
+        let config = JsonFormattingLayerConfig {
+            static_top_level_fields: HashMap::new(),
+            top_level_keys: HashSet::new(),
+            log_span_lifecycles: false,
+            additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+        };
+
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+        let formatting_layer = JsonFormattingLayer::new(
+            config,
+            test_writer.clone(),
+            serde_json::ser::CompactFormatter,
+        )
+        .unwrap();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(storage_layer)
+            .with(formatting_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = span!(
+                TracingLevel::INFO,
+                "connector_api_call",
+                api_message = tracing::field::Empty
+            );
+            let _guard = span.enter();
+
+            record_json(
+                "api_message",
+                json!({
+                    "request": {
+                        "method": "POST",
+                        "headers": {
+                            "content-type": "application/json"
+                        }
+                    },
+                    "response": {
+                        "status_code": 200
+                    }
+                }),
+            );
+
+            info!("Connector API call");
+        });
+
+        let output = test_writer.get_output();
+        let lines: Vec<&str> = output.trim().split('\n').collect();
+        let log_entry: Value = serde_json::from_str(lines[0]).unwrap();
+
+        assert!(log_entry["api_message"].is_object());
+        assert_eq!(log_entry["api_message"]["request"]["method"], "POST");
+        assert_eq!(
+            log_entry["api_message"]["request"]["headers"]["content-type"],
+            "application/json"
+        );
+        assert_eq!(log_entry["api_message"]["response"]["status_code"], 200);
     }
 
     #[test]

--- a/crates/log_utils/src/tracing.rs
+++ b/crates/log_utils/src/tracing.rs
@@ -95,6 +95,13 @@ pub struct LoggerConfig {
     /// This allows using a less verbose log level for third-party crates,
     /// while using a more verbose level for first-party crates, for example.
     pub global_filtering_directive: Option<String>,
+
+    /// An optional map of field name renames applied at serialization time.
+    ///
+    /// Keys are the original field names (as declared in spans/events), and values are the
+    /// desired output names in the JSON log. For example, `{"request_body" => "message.req_body"}`
+    /// causes any field named `request_body` to appear as `message.req_body` in the output.
+    pub field_rename_map: HashMap<String, String>,
 }
 
 /// Configuration for file logging.
@@ -287,6 +294,7 @@ pub enum LoggerError {
 ///         print_filtering_directive: DirectivePrintTarget::Stdout,
 ///     }),
 ///     global_filtering_directive: Some("info".to_string()),
+///     field_rename_map: HashMap::new(),
 /// };
 ///
 /// match build_logging_components(config) {
@@ -327,6 +335,7 @@ pub fn build_logging_components(config: LoggerConfig) -> Result<LoggingComponent
         top_level_keys: config.top_level_keys,
         log_span_lifecycles: config.log_span_lifecycles,
         additional_fields_placement: config.additional_fields_placement,
+        field_rename_map: config.field_rename_map,
     };
 
     // File logging
@@ -528,6 +537,7 @@ mod tests {
             top_level_keys: HashSet::new(),
             log_span_lifecycles: false,
             additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: HashMap::new(),
         };
 
         let layer = JsonFormattingLayer::new(
@@ -574,6 +584,7 @@ mod tests {
             top_level_keys,
             log_span_lifecycles: false,
             additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: HashMap::new(),
         };
 
         let layer = JsonFormattingLayer::new(
@@ -615,6 +626,7 @@ mod tests {
             top_level_keys: HashSet::new(),
             log_span_lifecycles: false,
             additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: HashMap::new(),
         };
 
         let storage_layer = SpanStorageLayer::new(HashSet::new());
@@ -677,6 +689,7 @@ mod tests {
             top_level_keys: HashSet::from(["user_id"]),
             log_span_lifecycles: false,
             additional_fields_placement: AdditionalFieldsPlacement::Nested("extra".to_string()),
+            field_rename_map: HashMap::new(),
         };
 
         let layer = JsonFormattingLayer::new(
@@ -722,6 +735,7 @@ mod tests {
             top_level_keys: HashSet::from(["user_id", "session_id", "operation"]),
             log_span_lifecycles: false,
             additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: HashMap::new(),
         };
 
         let formatting_layer = JsonFormattingLayer::new(
@@ -772,6 +786,7 @@ mod tests {
             top_level_keys: HashSet::new(),
             log_span_lifecycles: true, // Enable span lifecycle logging
             additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: HashMap::new(),
         };
 
         let formatting_layer = JsonFormattingLayer::new(
@@ -833,6 +848,7 @@ mod tests {
             top_level_keys: HashSet::new(),
             log_span_lifecycles: false,
             additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: HashMap::new(),
         };
 
         let result =
@@ -863,6 +879,7 @@ mod tests {
                 print_filtering_directive: DirectivePrintTarget::None,
             }),
             global_filtering_directive: None,
+            field_rename_map: HashMap::new(),
         };
 
         let result = build_logging_components(config);
@@ -901,6 +918,7 @@ mod tests {
                 print_filtering_directive: DirectivePrintTarget::None,
             }),
             global_filtering_directive: Some("warn".to_string()),
+            field_rename_map: HashMap::new(),
         };
 
         let result = build_logging_components(config);
@@ -942,6 +960,7 @@ mod tests {
             }),
             console_config: None, // Only test file logging
             global_filtering_directive: Some("info".to_string()),
+            field_rename_map: HashMap::new(),
         };
 
         let result = build_logging_components(config);
@@ -1056,5 +1075,96 @@ mod tests {
 
         // Clean up
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_field_rename_map() {
+        let test_writer = TestWriter::new();
+        let rename_map = HashMap::from([
+            ("request_body".to_string(), "message.req_body".to_string()),
+            ("gateway".to_string(), "connector".to_string()),
+        ]);
+
+        let config = JsonFormattingLayerConfig {
+            static_top_level_fields: HashMap::new(),
+            top_level_keys: HashSet::new(),
+            log_span_lifecycles: false,
+            additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: rename_map,
+        };
+
+        let layer = JsonFormattingLayer::new(
+            config,
+            test_writer.clone(),
+            serde_json::ser::CompactFormatter,
+        )
+        .unwrap();
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            info!(
+                request_body = "test_payload",
+                gateway = "stripe",
+                status = "ok",
+                "Test message"
+            );
+        });
+
+        let output = test_writer.get_output();
+        let lines: Vec<&str> = output.trim().split('\n').collect();
+        let log_entry: Value = serde_json::from_str(lines[0]).unwrap();
+
+        // Renamed fields should appear under new names
+        assert_eq!(log_entry["message.req_body"], "test_payload");
+        assert_eq!(log_entry["connector"], "stripe");
+
+        // Original names should NOT appear
+        assert!(log_entry.get("request_body").is_none());
+        assert!(log_entry.get("gateway").is_none());
+
+        // Non-renamed fields should be unaffected
+        assert_eq!(log_entry["status"], "ok");
+    }
+
+    #[test]
+    fn test_field_rename_map_with_span_fields() {
+        let test_writer = TestWriter::new();
+        let rename_map = HashMap::from([("flow_type".to_string(), "action".to_string())]);
+
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+
+        let config = JsonFormattingLayerConfig {
+            static_top_level_fields: HashMap::new(),
+            top_level_keys: HashSet::new(),
+            log_span_lifecycles: false,
+            additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+            field_rename_map: rename_map,
+        };
+
+        let formatting_layer = JsonFormattingLayer::new(
+            config,
+            test_writer.clone(),
+            serde_json::ser::CompactFormatter,
+        )
+        .unwrap();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(storage_layer)
+            .with(formatting_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = span!(TracingLevel::INFO, "handler", flow_type = "Authorize");
+            let _guard = span.enter();
+            info!("Processing");
+        });
+
+        let output = test_writer.get_output();
+        let lines: Vec<&str> = output.trim().split('\n').collect();
+        let log_entry: Value = serde_json::from_str(lines[0]).unwrap();
+
+        // Span field should be renamed
+        assert_eq!(log_entry["action"], "Authorize");
+        assert!(log_entry.get("flow_type").is_none());
     }
 }

--- a/crates/log_utils/src/tracing/formatter.rs
+++ b/crates/log_utils/src/tracing/formatter.rs
@@ -28,6 +28,7 @@ use super::{AdditionalFieldsPlacement, LoggerError, storage::Storage};
 /// - Keys from event or span data that should be promoted to the top level.
 /// - Behavior for logging span lifecycles (entries and exits).
 /// - Placement of additional (non-top-level) fields.
+/// - A field rename map for remapping field names at serialization time.
 #[derive(Clone, Debug)]
 pub struct JsonFormattingLayerConfig {
     /// A map of key-value pairs that are statically defined at initialization and included at the
@@ -44,6 +45,18 @@ pub struct JsonFormattingLayerConfig {
 
     /// Specifies how additional fields (not designated as top-level) are placed in the JSON output.
     pub additional_fields_placement: AdditionalFieldsPlacement,
+
+    /// An optional map of field name renames applied at serialization time.
+    ///
+    /// Keys are the original field names (as declared in `#[instrument(fields(...))]` or span/event
+    /// data), and values are the desired output names in the JSON log.
+    ///
+    /// For example, `{"request_body" => "message.req_body"}` causes any field named `request_body`
+    /// to be emitted as `message.req_body` in the JSON output.
+    ///
+    /// Only non-implicit fields are eligible for renaming; implicit keys (like `message`, `level`,
+    /// `time`, etc.) cannot be renamed.
+    pub field_rename_map: HashMap<String, String>,
 }
 
 /// Describes the type of a tracing record.
@@ -95,6 +108,7 @@ where
     top_level_keys: Arc<HashSet<&'static str>>,
     log_span_lifecycles: bool,
     additional_fields_placement: AdditionalFieldsPlacement,
+    field_rename_map: HashMap<String, String>,
 }
 
 impl<W, F> JsonFormattingLayer<W, F>
@@ -130,6 +144,7 @@ where
             top_level_keys: Arc::new(config.top_level_keys),
             log_span_lifecycles: config.log_span_lifecycles,
             additional_fields_placement: config.additional_fields_placement,
+            field_rename_map: config.field_rename_map,
         })
     }
 
@@ -170,6 +185,14 @@ where
         Ok(())
     }
 
+    /// Returns the renamed output key if a mapping exists, otherwise returns the original key.
+    fn resolve_field_name<'k>(&'k self, key: &'k str) -> &'k str {
+        self.field_rename_map
+            .get(key)
+            .map(String::as_str)
+            .unwrap_or(key)
+    }
+
     /// Common serialization implementation used to serialize both event and span fields.
     fn common_serialize<S>(
         &self,
@@ -202,21 +225,22 @@ where
         if let Some(storage) = storage {
             // Serialize event fields
             for (key, value) in storage.values() {
+                let output_key = self.resolve_field_name(key);
                 if super::keys::IMPLICIT_KEYS.contains(*key) {
                     tracing::warn!(
                         "Attempting to log a reserved key `{key}` (value: `{value:?}`) via event. \
                          Skipping."
                     );
                 } else if self.top_level_keys.contains(*key) {
-                    map_serializer.serialize_entry(key, value)?;
+                    map_serializer.serialize_entry(output_key, value)?;
                     explicit_entries_set.insert(*key);
                 } else {
                     if self.additional_fields_placement.is_nested() {
                         if let Some(map) = fields_to_nest.as_mut() {
-                            map.insert(key.to_string(), value.clone());
+                            map.insert(output_key.to_string(), value.clone());
                         }
                     } else {
-                        map_serializer.serialize_entry(key, value)?;
+                        map_serializer.serialize_entry(output_key, value)?;
                     }
                     explicit_entries_set.insert(key);
                 }
@@ -232,19 +256,20 @@ where
                     .iter()
                     .filter(|(k, _v)| !explicit_entries_set.contains(*k))
                 {
+                    let output_key = self.resolve_field_name(key);
                     if super::keys::IMPLICIT_KEYS.contains(*key) {
                         tracing::warn!(
                             "Attempting to log a reserved key `{key}` (value: `{value:?}`) via span. \
                              Skipping."
                         );
                     } else if self.top_level_keys.contains(*key) {
-                        map_serializer.serialize_entry(key, value)?;
+                        map_serializer.serialize_entry(output_key, value)?;
                     } else if self.additional_fields_placement.is_nested() {
                         if let Some(map) = fields_to_nest.as_mut() {
-                            map.insert(key.to_string(), value.clone());
+                            map.insert(output_key.to_string(), value.clone());
                         }
                     } else {
-                        map_serializer.serialize_entry(key, value)?;
+                        map_serializer.serialize_entry(output_key, value)?;
                     }
                 }
             }

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -12,7 +12,28 @@ use tracing::{
     field::{Field, Visit},
     span::{Attributes, Record},
 };
-use tracing_subscriber::{Layer, layer::Context};
+use tracing_subscriber::{Layer, Registry, layer::Context, registry::LookupSpan};
+
+/// Records a JSON value on the current tracing span.
+///
+/// This is a stable extension point for structured JSON fields when the active subscriber uses
+/// [`SpanStorageLayer`].
+pub fn record_json(field: &'static str, value: serde_json::Value) {
+    let _ = tracing::Span::current().with_subscriber(|(id, dispatch)| {
+        let Some(registry) = dispatch.downcast_ref::<Registry>() else {
+            return;
+        };
+        let Some(span) = registry.span(id) else {
+            return;
+        };
+        let mut extensions = span.extensions_mut();
+        let Some(storage) = extensions.get_mut::<Storage<'_>>() else {
+            return;
+        };
+
+        storage.record_value(field, value);
+    });
+}
 
 /// A [`tracing_subscriber::Layer`] that enables storing key-value data within span extensions.
 /// It also handles propagation of "persistent" keys to parent spans and records span duration.
@@ -146,9 +167,7 @@ impl Visit for Storage<'_> {
     }
 }
 
-impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer<S>
-    for SpanStorageLayer
-{
+impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for SpanStorageLayer {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         #[expect(clippy::expect_used)]
         let span = ctx


### PR DESCRIPTION
## Summary
- Adds a configurable `HashMap<String, String>` (`field_rename_map`) to `JsonFormattingLayerConfig` and `LoggerConfig`
- Remaps field names at serialization time in `common_serialize()` via a `resolve_field_name()` helper
- Enables self-deploying services to customize log field names (e.g. `"request_body"` → `"message.req_body"`) via config without modifying source code
- Includes 2 new unit tests: `test_field_rename_map` (event fields) and `test_field_rename_map_with_span_fields` (span fields)
- All 12 tests pass

## Motivation
Services like UCS need to emit logs with field names matching their deployment's schema (e.g., Euler log format). Currently field names are baked in at compile time. This change allows runtime remapping via a simple HashMap passed at logger initialization, loaded from deployment config (e.g., `development.toml`).

## Test plan
- [x] `cargo test -p log_utils --features tracing --lib` — all 12 tests pass
- [x] `test_field_rename_map` verifies event fields are renamed and originals are absent
- [x] `test_field_rename_map_with_span_fields` verifies span fields are renamed correctly
- [x] Empty rename map preserves existing behavior (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)