### PR TITLE
refactor(log_utils): expose `Storage` API under `tracing-storage-api` feature

### DIFF
--- a/crates/log_utils/Cargo.toml
+++ b/crates/log_utils/Cargo.toml
@@ -23,6 +23,7 @@ tracing = [
     "dep:tracing-appender",
     "dep:tracing-subscriber",
 ]
+tracing-storage-api = ["tracing"]
 
 [dependencies]
 gethostname = { version = "1.1.0", optional = true }

--- a/crates/log_utils/src/lib.rs
+++ b/crates/log_utils/src/lib.rs
@@ -14,6 +14,10 @@
 //! # Features
 //!
 //! - `tracing` - Enables `tracing`-based logging infrastructure (disabled by default)
+//! - `tracing-storage-api` - Exposes the span [`Storage`] type and its methods publicly (implies
+//!   `tracing`).
+//!   Most users should not need this feature, unless they're trying to work with the current
+//!   span's storage.
 //!
 //! # Example
 //!
@@ -96,6 +100,60 @@
 //!     Err(e) => eprintln!("Failed to initialize logging: {e}"),
 //! }
 //! ```
+//!
+//! # Reading from and recording values into the current span
+//!
+//! With the `tracing-storage-api` feature, the [`Storage`] type and its methods are available for
+//! working with the current span's storage: use [`Storage::with_current_span`] to read values from
+//! it, use [`Storage::with_current_span_mut`] instead if you need to mutate the storage, such as
+//! to record values.
+//!
+//! For simple values (strings, numbers, booleans), prefer `tracing`'s own API: declare the field
+//! on the span, then record it with [`tracing::Span::current().record()`][::tracing::Span::record].
+//! This requires only the `tracing` feature.
+//! Note that [`Span::record()`][::tracing::Span::record] silently drops fields that were not
+//! declared on the span.
+//! Use [`Storage::with_current_span_mut`] for ad-hoc keys or values
+//! [`Span::record`][::tracing::Span::record] cannot carry.
+//!
+//! ```
+//! # #[cfg(feature = "tracing-storage-api")]
+//! # {
+//! use std::collections::HashSet;
+//!
+//! use log_utils::{SpanStorageLayer, Storage};
+//! use serde_json::json;
+//! use tracing_subscriber::layer::SubscriberExt;
+//!
+//! let subscriber = tracing_subscriber::registry().with(SpanStorageLayer::new(HashSet::new()));
+//!
+//! tracing::subscriber::with_default(subscriber, || {
+//!     let span = tracing::info_span!("my_span", user_id = tracing::field::Empty);
+//!     let _guard = span.enter();
+//!
+//!     // Recording simple values: use `Span::record()`
+//!     tracing::Span::current().record("user_id", 42);
+//!
+//!     // Recording structured values: use `Storage::with_current_span_mut()`
+//!     Storage::with_current_span_mut(|storage| {
+//!         storage.record_value("my_field", json!({ "nested": true }));
+//!     });
+//!
+//!     // Reading values: use `Storage::with_current_span()`
+//!     let recorded = Storage::with_current_span(|storage| {
+//!         (
+//!             storage.values().get("my_field").cloned(),
+//!             storage.values().get("user_id").cloned(),
+//!         )
+//!     });
+//!
+//!     assert_eq!(
+//!         recorded,
+//!         Some((Some(json!({ "nested": true })), Some(json!(42))))
+//!     );
+//! });
+//! # }
+//! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(test(attr(deny(warnings))))]
@@ -103,6 +161,8 @@
 #[cfg(feature = "tracing")]
 mod tracing;
 
+#[cfg(feature = "tracing-storage-api")]
+pub use self::tracing::Storage;
 #[cfg(feature = "tracing")]
 pub use self::tracing::{
     AdditionalFieldsPlacement, ConsoleLogFormat, ConsoleLoggingConfig, DirectivePrintTarget,

--- a/crates/log_utils/src/tracing.rs
+++ b/crates/log_utils/src/tracing.rs
@@ -12,6 +12,11 @@ pub use tracing::Level;
 pub use tracing_appender::rolling::Rotation;
 use tracing_subscriber::{EnvFilter, Layer};
 
+#[cfg_attr(
+    all(not(feature = "tracing-storage-api"), not(test)),
+    expect(unused_imports)
+)]
+pub use self::storage::Storage;
 pub use self::{
     formatter::{JsonFormattingLayer, JsonFormattingLayerConfig, RecordType},
     storage::SpanStorageLayer,
@@ -992,5 +997,135 @@ mod tests {
 
         // Clean up
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_with_current_span_reads_storage() {
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+        let subscriber = tracing_subscriber::registry().with(storage_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            // No span entered yet
+            assert!(Storage::with_current_span(|_storage| ()).is_none());
+
+            let span = span!(TracingLevel::INFO, "my_span", user_id = 42);
+            let _guard = span.enter();
+
+            let user_id =
+                Storage::with_current_span(|storage| storage.values().get("user_id").cloned())
+                    .flatten();
+
+            assert_eq!(user_id, Some(json!(42)));
+        });
+    }
+
+    #[test]
+    fn test_with_current_span_and_with_current_span_mut_read_values_and_message() {
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+        let subscriber = tracing_subscriber::registry().with(storage_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = span!(
+                TracingLevel::INFO,
+                "my_span",
+                user_id = 42,
+                message = "hello"
+            );
+            let _guard = span.enter();
+
+            let snapshot = Storage::with_current_span(|storage| {
+                (
+                    storage.values().get("user_id").cloned(),
+                    storage.message().map(str::to_owned),
+                )
+            });
+            assert_eq!(snapshot, Some((Some(json!(42)), Some("hello".to_owned()))));
+
+            let snapshot = Storage::with_current_span_mut(|storage| {
+                (
+                    storage.values().get("user_id").cloned(),
+                    storage.message().map(str::to_owned),
+                )
+            });
+            assert_eq!(snapshot, Some((Some(json!(42)), Some("hello".to_owned()))));
+        });
+    }
+
+    #[test]
+    fn test_with_current_span_mut_records_value() {
+        let test_writer = TestWriter::new();
+
+        let config = JsonFormattingLayerConfig {
+            static_top_level_fields: HashMap::new(),
+            top_level_keys: HashSet::new(),
+            log_span_lifecycles: false,
+            additional_fields_placement: AdditionalFieldsPlacement::TopLevel,
+        };
+
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+        let formatting_layer = JsonFormattingLayer::new(
+            config,
+            test_writer.clone(),
+            serde_json::ser::CompactFormatter,
+        )
+        .unwrap();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(storage_layer)
+            .with(formatting_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = span!(TracingLevel::INFO, "my_span");
+            let _guard = span.enter();
+
+            Storage::with_current_span_mut(|storage| {
+                storage.record_value(
+                    "user_details",
+                    json!({
+                        "name": "John Doe",
+                        "age": 43,
+                        "phones": [
+                            "+44 1234567",
+                            "+44 2345678"
+                        ]
+                    }),
+                );
+            });
+
+            info!("User details");
+        });
+
+        let output = test_writer.get_output();
+        let lines: Vec<&str> = output.trim().split('\n').collect();
+        let log_entry: Value = serde_json::from_str(lines[0]).unwrap();
+
+        assert!(log_entry["user_details"].is_object());
+        assert_eq!(log_entry["user_details"]["name"], "John Doe");
+        assert_eq!(log_entry["user_details"]["age"], 43);
+        assert_eq!(log_entry["user_details"]["phones"][0], "+44 1234567");
+    }
+
+    #[test]
+    fn test_with_current_span_mut_returns_none_without_current_span() {
+        let storage_layer = SpanStorageLayer::new(HashSet::new());
+        let subscriber = tracing_subscriber::registry().with(storage_layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let result = Storage::with_current_span_mut(|_storage| {});
+            assert!(result.is_none());
+        });
+    }
+
+    #[test]
+    fn test_with_current_span_mut_returns_none_without_storage_layer() {
+        let subscriber = tracing_subscriber::registry();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = span!(TracingLevel::INFO, "my_span");
+            let _guard = span.enter();
+
+            let result = Storage::with_current_span_mut(|_storage| {});
+            assert!(result.is_none());
+        });
     }
 }

--- a/crates/log_utils/src/tracing.rs
+++ b/crates/log_utils/src/tracing.rs
@@ -41,7 +41,9 @@ mod keys {
     pub(crate) const FULL_NAME: &str = "full_name";
     pub(crate) const ELAPSED_MILLISECONDS: &str = "elapsed_milliseconds";
 
-    pub(crate) static IMPLICIT_KEYS: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
+    // If you add or remove a key in this list, also update the list documented on
+    // `Storage::is_reserved()`.
+    static RESERVED_KEYS: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
         [
             MESSAGE,
             LEVEL,
@@ -60,6 +62,10 @@ mod keys {
         .copied()
         .collect()
     });
+
+    pub(crate) fn is_reserved(key: &str) -> bool {
+        RESERVED_KEYS.contains(key)
+    }
 }
 
 /// Comprehensive configuration for the entire logging system.

--- a/crates/log_utils/src/tracing/formatter.rs
+++ b/crates/log_utils/src/tracing/formatter.rs
@@ -113,7 +113,7 @@ where
         let hostname = gethostname::gethostname().to_string_lossy().into_owned();
 
         for key in config.static_top_level_fields.keys() {
-            if super::keys::IMPLICIT_KEYS.contains(key.as_str()) {
+            if super::keys::is_reserved(key.as_str()) {
                 return Err(LoggerError::Configuration(format!(
                     "A reserved key `{key}` was included in `static_top_level_fields` in the \
                      log formatting layer"
@@ -202,7 +202,7 @@ where
         if let Some(storage) = storage {
             // Serialize event fields
             for (key, value) in storage.values() {
-                if super::keys::IMPLICIT_KEYS.contains(*key) {
+                if super::keys::is_reserved(key) {
                     tracing::warn!(
                         "Attempting to log a reserved key `{key}` (value: `{value:?}`) via event. \
                          Skipping."
@@ -232,7 +232,7 @@ where
                     .iter()
                     .filter(|(k, _v)| !explicit_entries_set.contains(*k))
                 {
-                    if super::keys::IMPLICIT_KEYS.contains(*key) {
+                    if super::keys::is_reserved(key) {
                         tracing::warn!(
                             "Attempting to log a reserved key `{key}` (value: `{value:?}`) via span. \
                              Skipping."

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -46,12 +46,22 @@ pub struct Storage<'a> {
 }
 
 impl<'a> Storage<'a> {
+    /// Returns `true` if `key` is reserved by the logging infrastructure and cannot be recorded
+    /// via [`Self::record_value`].
+    ///
+    /// The reserved keys are: `message`, `level`, `target`, `line`, `file`, `time`, `hostname`,
+    /// `pid`, `thread_id`, `thread_name`, `fn`, `full_name`.
+    /// This list may grow in future releases.
+    pub fn is_reserved(key: &str) -> bool {
+        super::keys::is_reserved(key)
+    }
+
     /// Records a key-value pair into the storage.
     ///
-    /// If the `key` is one of the [`IMPLICIT_KEYS`][crate::keys::IMPLICIT_KEYS],
-    /// a warning is logged, and the value is not inserted.
+    /// If `key` is reserved (see [`is_reserved()`][Self::is_reserved]), a warning is logged,
+    /// and the value is not recorded.
     pub fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
-        if super::keys::IMPLICIT_KEYS.contains(key) {
+        if Self::is_reserved(key) {
             tracing::warn!(
                 "Attempting to record a reserved key `{key}` (value: {value:?}). Skipping."
             );

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -37,7 +37,7 @@ impl SpanStorageLayer {
 ///
 /// This struct is typically stored in a span's extensions via [`SpanStorageLayer`].
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Storage<'a> {
+pub struct Storage<'a> {
     /// The collected key-value pairs for the span.
     values: HashMap<&'a str, serde_json::Value>,
 
@@ -50,7 +50,7 @@ impl<'a> Storage<'a> {
     ///
     /// If the `key` is one of the [`IMPLICIT_KEYS`][crate::keys::IMPLICIT_KEYS],
     /// a warning is logged, and the value is not inserted.
-    pub(crate) fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
+    pub fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
         if super::keys::IMPLICIT_KEYS.contains(key) {
             tracing::warn!(
                 "Attempting to record a reserved key `{key}` (value: {value:?}). Skipping."
@@ -60,12 +60,72 @@ impl<'a> Storage<'a> {
         }
     }
 
-    pub(crate) fn values(&self) -> &HashMap<&'a str, serde_json::Value> {
+    /// Returns the key-value pairs recorded in this storage.
+    pub fn values(&self) -> &HashMap<&'a str, serde_json::Value> {
         &self.values
     }
 
-    pub(crate) fn message(&self) -> Option<&str> {
+    /// Returns the primary message of an event, if captured.
+    pub fn message(&self) -> Option<&str> {
         self.message.as_deref()
+    }
+
+    /// Runs `f` with the [`Storage`] of the current span, if any.
+    ///
+    /// Returns `None` if any of the following conditions hold:
+    ///
+    /// - There is no current span.
+    /// - The current subscriber is not a [`Registry`][tracing_subscriber::Registry]-based
+    ///   subscriber using [`SpanStorageLayer`].
+    /// - The current span has no [`Storage`] associated with it.
+    ///
+    /// Use [`with_current_span_mut()`][Self::with_current_span_mut] to record values into the storage.
+    #[cfg_attr(
+        all(not(feature = "tracing-storage-api"), not(test)),
+        expect(dead_code)
+    )]
+    pub fn with_current_span<T>(f: impl FnOnce(&Storage<'_>) -> T) -> Option<T> {
+        use tracing_subscriber::{Registry, registry::LookupSpan};
+
+        tracing::Span::current()
+            .with_subscriber(|(id, dispatch)| {
+                let registry = dispatch.downcast_ref::<Registry>()?;
+                let span = registry.span(id)?;
+                let extensions = span.extensions();
+                let storage = extensions.get::<Storage<'_>>()?;
+
+                Some(f(storage))
+            })
+            .flatten()
+    }
+
+    /// Runs `f` with the [`Storage`] of the current span, if any.
+    ///
+    /// Returns `None` if any of the following conditions hold:
+    ///
+    /// - There is no current span.
+    /// - The current subscriber is not a [`Registry`][tracing_subscriber::Registry]-based
+    ///   subscriber using [`SpanStorageLayer`].
+    /// - The current span has no [`Storage`] associated with it.
+    ///
+    /// Use [`Self::with_current_span`] to read the storage without modifying it.
+    #[cfg_attr(
+        all(not(feature = "tracing-storage-api"), not(test)),
+        expect(dead_code)
+    )]
+    pub fn with_current_span_mut<T>(f: impl FnOnce(&mut Storage<'_>) -> T) -> Option<T> {
+        use tracing_subscriber::{Registry, registry::LookupSpan};
+
+        tracing::Span::current()
+            .with_subscriber(|(id, dispatch)| {
+                let registry = dispatch.downcast_ref::<Registry>()?;
+                let span = registry.span(id)?;
+                let mut extensions = span.extensions_mut();
+                let storage = extensions.get_mut::<Storage<'_>>()?;
+
+                Some(f(storage))
+            })
+            .flatten()
     }
 }
 


### PR DESCRIPTION
This PR exposes the `Storage` API from the `log_utils` crate behind a new opt-in Cargo feature, `tracing-storage-api`, for consumers of the crate that may want to work with span fields.

This PR includes the following changes:

- `Storage`, `Storage::record_value()`, `Storage::values()` and `Storage::message()` are now `pub` visible.
- `Storage::is_reserved()` introduced to document the reserved keys that would not be recorded by `Storage::record_value()`.
- `Storage::with_current_span()` and `Storage::with_current_span_mut()` introduced to allow consumers of the crate to read from and write to the span storage, respectively.