### PR TITLE
refactor(log_utils): use Cow<'static, str> keys in Storage

### DIFF
--- a/crates/log_utils/src/tracing/formatter.rs
+++ b/crates/log_utils/src/tracing/formatter.rs
@@ -176,7 +176,7 @@ where
         map_serializer: &mut impl SerializeMap<Error = serde_json::Error>,
         metadata: &Metadata<'_>,
         span: Option<&SpanRef<'_, S>>,
-        storage: Option<&Storage<'_>>,
+        storage: Option<&Storage>,
         name: &str,
         message: &str,
     ) -> Result<(), LoggerError>
@@ -207,13 +207,13 @@ where
                         "Attempting to log a reserved key `{key}` (value: `{value:?}`) via event. \
                          Skipping."
                     );
-                } else if self.top_level_keys.contains(*key) {
+                } else if self.top_level_keys.contains(key.as_str()) {
                     map_serializer.serialize_entry(key, value)?;
-                    explicit_entries_set.insert(*key);
+                    explicit_entries_set.insert(key);
                 } else {
                     if self.additional_fields_placement.is_nested() {
                         if let Some(map) = fields_to_nest.as_mut() {
-                            map.insert(key.to_string(), value.clone());
+                            map.insert(key.clone(), value.clone());
                         }
                     } else {
                         map_serializer.serialize_entry(key, value)?;
@@ -226,22 +226,22 @@ where
         // Serialize span fields
         if let Some(span_ref) = &span {
             let extensions = span_ref.extensions();
-            if let Some(visitor) = extensions.get::<Storage<'_>>() {
+            if let Some(visitor) = extensions.get::<Storage>() {
                 for (key, value) in visitor
                     .values()
                     .iter()
-                    .filter(|(k, _v)| !explicit_entries_set.contains(*k))
+                    .filter(|(k, _v)| !explicit_entries_set.contains(k.as_str()))
                 {
                     if super::keys::is_reserved(key) {
                         tracing::warn!(
                             "Attempting to log a reserved key `{key}` (value: `{value:?}`) via span. \
                              Skipping."
                         );
-                    } else if self.top_level_keys.contains(*key) {
+                    } else if self.top_level_keys.contains(key.as_str()) {
                         map_serializer.serialize_entry(key, value)?;
                     } else if self.additional_fields_placement.is_nested() {
                         if let Some(map) = fields_to_nest.as_mut() {
-                            map.insert(key.to_string(), value.clone());
+                            map.insert(key.clone(), value.clone());
                         }
                     } else {
                         map_serializer.serialize_entry(key, value)?;
@@ -348,7 +348,7 @@ where
     fn event_message<S>(
         span: Option<&SpanRef<'_, S>>,
         event: &Event<'_>,
-        storage: &Storage<'_>,
+        storage: &Storage,
     ) -> String
     where
         S: Subscriber + for<'a> LookupSpan<'a>,

--- a/crates/log_utils/src/tracing/formatter.rs
+++ b/crates/log_utils/src/tracing/formatter.rs
@@ -202,23 +202,24 @@ where
         if let Some(storage) = storage {
             // Serialize event fields
             for (key, value) in storage.values() {
-                if super::keys::is_reserved(key) {
+                let key_str: &str = key.as_ref();
+                if super::keys::is_reserved(key_str) {
                     tracing::warn!(
                         "Attempting to log a reserved key `{key}` (value: `{value:?}`) via event. \
                          Skipping."
                     );
-                } else if self.top_level_keys.contains(key.as_str()) {
-                    map_serializer.serialize_entry(key, value)?;
-                    explicit_entries_set.insert(key);
+                } else if self.top_level_keys.contains(key_str) {
+                    map_serializer.serialize_entry(key_str, value)?;
+                    explicit_entries_set.insert(key_str);
                 } else {
                     if self.additional_fields_placement.is_nested() {
                         if let Some(map) = fields_to_nest.as_mut() {
-                            map.insert(key.clone(), value.clone());
+                            map.insert(key_str.to_owned(), value.clone());
                         }
                     } else {
-                        map_serializer.serialize_entry(key, value)?;
+                        map_serializer.serialize_entry(key_str, value)?;
                     }
-                    explicit_entries_set.insert(key);
+                    explicit_entries_set.insert(key_str);
                 }
             }
         }
@@ -230,21 +231,22 @@ where
                 for (key, value) in visitor
                     .values()
                     .iter()
-                    .filter(|(k, _v)| !explicit_entries_set.contains(k.as_str()))
+                    .filter(|(k, _v)| !explicit_entries_set.contains(k.as_ref()))
                 {
-                    if super::keys::is_reserved(key) {
+                    let key_str: &str = key.as_ref();
+                    if super::keys::is_reserved(key_str) {
                         tracing::warn!(
                             "Attempting to log a reserved key `{key}` (value: `{value:?}`) via span. \
                              Skipping."
                         );
-                    } else if self.top_level_keys.contains(key.as_str()) {
-                        map_serializer.serialize_entry(key, value)?;
+                    } else if self.top_level_keys.contains(key_str) {
+                        map_serializer.serialize_entry(key_str, value)?;
                     } else if self.additional_fields_placement.is_nested() {
                         if let Some(map) = fields_to_nest.as_mut() {
-                            map.insert(key.clone(), value.clone());
+                            map.insert(key_str.to_owned(), value.clone());
                         }
                     } else {
-                        map_serializer.serialize_entry(key, value)?;
+                        map_serializer.serialize_entry(key_str, value)?;
                     }
                 }
             }

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -315,7 +315,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
                             .extensions_mut()
                             .get_mut::<Storage>()
                             .map(|parent_storage| {
-                                parent_storage.values.insert(k.clone(), v.clone());
+                                parent_storage.record_value(k.clone(), v.clone());
                             })
                     });
                 });

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -98,7 +98,7 @@ impl Storage {
         all(not(feature = "tracing-storage-api"), not(test)),
         expect(dead_code)
     )]
-    pub fn with_current_span<T>(f: impl FnOnce(&Storage) -> T) -> Option<T> {
+    pub fn with_current_span<T>(f: impl FnOnce(&Self) -> T) -> Option<T> {
         use tracing_subscriber::{Registry, registry::LookupSpan};
 
         tracing::Span::current()
@@ -106,7 +106,7 @@ impl Storage {
                 let registry = dispatch.downcast_ref::<Registry>()?;
                 let span = registry.span(id)?;
                 let extensions = span.extensions();
-                let storage = extensions.get::<Storage>()?;
+                let storage = extensions.get::<Self>()?;
 
                 Some(f(storage))
             })
@@ -127,7 +127,7 @@ impl Storage {
         all(not(feature = "tracing-storage-api"), not(test)),
         expect(dead_code)
     )]
-    pub fn with_current_span_mut<T>(f: impl FnOnce(&mut Storage) -> T) -> Option<T> {
+    pub fn with_current_span_mut<T>(f: impl FnOnce(&mut Self) -> T) -> Option<T> {
         use tracing_subscriber::{Registry, registry::LookupSpan};
 
         tracing::Span::current()
@@ -135,7 +135,7 @@ impl Storage {
                 let registry = dispatch.downcast_ref::<Registry>()?;
                 let span = registry.span(id)?;
                 let mut extensions = span.extensions_mut();
-                let storage = extensions.get_mut::<Storage>()?;
+                let storage = extensions.get_mut::<Self>()?;
 
                 Some(f(storage))
             })

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -37,15 +37,6 @@ impl SpanStorageLayer {
 /// Holds key-value data recorded for a span or an event.
 ///
 /// This struct is typically stored in a span's extensions via [`SpanStorageLayer`].
-///
-/// Keys use [`Cow<'static, str>`] to get the best of both worlds:
-/// - Compile-time field names (from `#[instrument]` and `span!()` macros) are stored as
-///   `Cow::Borrowed(&'static str)` — zero allocation, just a pointer copy.
-/// - Runtime-determined field names (from configuration or request metadata) are stored as
-///   `Cow::Owned(String)` — owned by Storage and freed when the span closes.
-///
-/// This avoids both the lifetime constraints of `&'a str` keys and the unconditional
-/// allocation overhead of `String` keys for the common case of declared span fields.
 #[derive(Clone, Debug, Default)]
 pub struct Storage {
     /// The collected key-value pairs for the span.
@@ -70,11 +61,6 @@ impl Storage {
     ///
     /// If `key` is reserved (see [`is_reserved()`][Self::is_reserved]), a warning is logged,
     /// and the value is not recorded.
-    ///
-    /// Accepts any type that converts into `Cow<'static, str>`:
-    /// - `&'static str` → zero-copy `Cow::Borrowed`
-    /// - `String` → `Cow::Owned`
-    /// - `Cow<'static, str>` → passed through
     pub fn record_value(&mut self, key: impl Into<Cow<'static, str>>, value: serde_json::Value) {
         let key = key.into();
         if Self::is_reserved(&key) {

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -158,7 +158,8 @@ impl Storage {
 // Implement `Visit` to capture span or event fields into the `Storage` map.
 //
 // `field.name()` returns `&'static str` (field names are baked into the binary by `tracing`),
-// so we use `Cow::Borrowed` here — zero allocation for declared span fields.
+// so `record_value` receives `&'static str` → `Cow::Borrowed` — zero allocation for declared
+// span fields.
 impl Visit for Storage {
     fn record_f64(&mut self, field: &Field, value: f64) {
         if field.name() == super::keys::MESSAGE {
@@ -166,8 +167,7 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.values
-                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
+            self.record_value(field.name(), serde_json::Value::from(value));
         }
     }
 
@@ -177,8 +177,7 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.values
-                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
+            self.record_value(field.name(), serde_json::Value::from(value));
         }
     }
 
@@ -188,8 +187,7 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.values
-                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
+            self.record_value(field.name(), serde_json::Value::from(value));
         }
     }
 
@@ -199,8 +197,7 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.values
-                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
+            self.record_value(field.name(), serde_json::Value::from(value));
         }
     }
 
@@ -208,8 +205,7 @@ impl Visit for Storage {
         if field.name() == super::keys::MESSAGE {
             self.message = Some(value.to_string()); // `record_str()` is preferred for `message`
         } else {
-            self.values
-                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
+            self.record_value(field.name(), serde_json::Value::from(value));
         }
     }
 
@@ -225,20 +221,17 @@ impl Visit for Storage {
                 name if name.starts_with("log.") => (),
                 name if name.starts_with("r#") => {
                     #[expect(clippy::expect_used)]
-                    let stripped = name.get(2..).expect(
-                        "field name using raw identifiers must have at least two characters",
-                    );
+                    let stripped = name
+                        .get(2..)
+                        .expect(
+                            "field name using raw identifiers must have at least two characters",
+                        )
+                        .to_owned();
                     // Raw identifier prefix is stripped, so we need an owned key
-                    self.values.insert(
-                        Cow::Owned(stripped.to_owned()),
-                        serde_json::Value::from(format!("{value:?}")),
-                    );
+                    self.record_value(stripped, serde_json::Value::from(format!("{value:?}")));
                 }
                 name => {
-                    self.values.insert(
-                        Cow::Borrowed(name),
-                        serde_json::Value::from(format!("{value:?}")),
-                    );
+                    self.record_value(name, serde_json::Value::from(format!("{value:?}")));
                 }
             };
         }
@@ -322,9 +315,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
                             .extensions_mut()
                             .get_mut::<Storage>()
                             .map(|parent_storage| {
-                                parent_storage
-                                    .values
-                                    .insert(k.clone(), v.clone());
+                                parent_storage.values.insert(k.clone(), v.clone());
                             })
                     });
                 });

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -2,6 +2,7 @@
 //! key-value data from tracing spans.
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fmt,
     time::Instant,
@@ -37,13 +38,18 @@ impl SpanStorageLayer {
 ///
 /// This struct is typically stored in a span's extensions via [`SpanStorageLayer`].
 ///
-/// Keys are owned `String`s, which allows both compile-time field names (from `#[instrument]`
-/// and `span!()` macros) and runtime-determined field names (from configuration or request
-/// metadata) to be stored without requiring `Box::leak` or other lifetime workarounds.
+/// Keys use [`Cow<'static, str>`] to get the best of both worlds:
+/// - Compile-time field names (from `#[instrument]` and `span!()` macros) are stored as
+///   `Cow::Borrowed(&'static str)` — zero allocation, just a pointer copy.
+/// - Runtime-determined field names (from configuration or request metadata) are stored as
+///   `Cow::Owned(String)` — owned by Storage and freed when the span closes.
+///
+/// This avoids both the lifetime constraints of `&'a str` keys and the unconditional
+/// allocation overhead of `String` keys for the common case of declared span fields.
 #[derive(Clone, Debug, Default)]
 pub struct Storage {
     /// The collected key-value pairs for the span.
-    values: HashMap<String, serde_json::Value>,
+    values: HashMap<Cow<'static, str>, serde_json::Value>,
 
     /// The primary message of an event, if captured.
     message: Option<String>,
@@ -64,18 +70,24 @@ impl Storage {
     ///
     /// If `key` is reserved (see [`is_reserved()`][Self::is_reserved]), a warning is logged,
     /// and the value is not recorded.
-    pub fn record_value(&mut self, key: &str, value: serde_json::Value) {
-        if Self::is_reserved(key) {
+    ///
+    /// Accepts any type that converts into `Cow<'static, str>`:
+    /// - `&'static str` → zero-copy `Cow::Borrowed`
+    /// - `String` → `Cow::Owned`
+    /// - `Cow<'static, str>` → passed through
+    pub fn record_value(&mut self, key: impl Into<Cow<'static, str>>, value: serde_json::Value) {
+        let key = key.into();
+        if Self::is_reserved(&key) {
             tracing::warn!(
                 "Attempting to record a reserved key `{key}` (value: {value:?}). Skipping."
             );
         } else {
-            self.values.insert(key.to_owned(), value);
+            self.values.insert(key, value);
         }
     }
 
     /// Returns the key-value pairs recorded in this storage.
-    pub fn values(&self) -> &HashMap<String, serde_json::Value> {
+    pub fn values(&self) -> &HashMap<Cow<'static, str>, serde_json::Value> {
         &self.values
     }
 
@@ -144,6 +156,9 @@ impl Storage {
 }
 
 // Implement `Visit` to capture span or event fields into the `Storage` map.
+//
+// `field.name()` returns `&'static str` (field names are baked into the binary by `tracing`),
+// so we use `Cow::Borrowed` here — zero allocation for declared span fields.
 impl Visit for Storage {
     fn record_f64(&mut self, field: &Field, value: f64) {
         if field.name() == super::keys::MESSAGE {
@@ -151,7 +166,8 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.record_value(field.name(), serde_json::Value::from(value));
+            self.values
+                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
         }
     }
 
@@ -161,7 +177,8 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.record_value(field.name(), serde_json::Value::from(value));
+            self.values
+                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
         }
     }
 
@@ -171,7 +188,8 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.record_value(field.name(), serde_json::Value::from(value));
+            self.values
+                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
         }
     }
 
@@ -181,7 +199,8 @@ impl Visit for Storage {
                 self.message = Some(value.to_string());
             }
         } else {
-            self.record_value(field.name(), serde_json::Value::from(value));
+            self.values
+                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
         }
     }
 
@@ -189,7 +208,8 @@ impl Visit for Storage {
         if field.name() == super::keys::MESSAGE {
             self.message = Some(value.to_string()); // `record_str()` is preferred for `message`
         } else {
-            self.record_value(field.name(), serde_json::Value::from(value));
+            self.values
+                .insert(Cow::Borrowed(field.name()), serde_json::Value::from(value));
         }
     }
 
@@ -204,16 +224,21 @@ impl Visit for Storage {
                 // Skip fields which are already handled
                 name if name.starts_with("log.") => (),
                 name if name.starts_with("r#") => {
-                    self.record_value(
-                        #[expect(clippy::expect_used)]
-                        name.get(2..).expect(
-                            "field name using raw identifiers must have at least two characters",
-                        ),
+                    #[expect(clippy::expect_used)]
+                    let stripped = name.get(2..).expect(
+                        "field name using raw identifiers must have at least two characters",
+                    );
+                    // Raw identifier prefix is stripped, so we need an owned key
+                    self.values.insert(
+                        Cow::Owned(stripped.to_owned()),
                         serde_json::Value::from(format!("{value:?}")),
                     );
                 }
                 name => {
-                    self.record_value(name, serde_json::Value::from(format!("{value:?}")));
+                    self.values.insert(
+                        Cow::Borrowed(name),
+                        serde_json::Value::from(format!("{value:?}")),
+                    );
                 }
             };
         }
@@ -290,13 +315,17 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
             storage
                 .values
                 .iter()
-                .filter(|(k, _v)| self.persistent_keys.contains(k.as_str()))
+                .filter(|(k, _v)| self.persistent_keys.contains(k.as_ref()))
                 .for_each(|(k, v)| {
                     span.parent().and_then(|parent_span| {
                         parent_span
                             .extensions_mut()
                             .get_mut::<Storage>()
-                            .map(|parent_storage| parent_storage.record_value(k, v.to_owned()))
+                            .map(|parent_storage| {
+                                parent_storage
+                                    .values
+                                    .insert(k.clone(), v.clone());
+                            })
                     });
                 });
         }

--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -36,16 +36,20 @@ impl SpanStorageLayer {
 /// Holds key-value data recorded for a span or an event.
 ///
 /// This struct is typically stored in a span's extensions via [`SpanStorageLayer`].
+///
+/// Keys are owned `String`s, which allows both compile-time field names (from `#[instrument]`
+/// and `span!()` macros) and runtime-determined field names (from configuration or request
+/// metadata) to be stored without requiring `Box::leak` or other lifetime workarounds.
 #[derive(Clone, Debug, Default)]
-pub struct Storage<'a> {
+pub struct Storage {
     /// The collected key-value pairs for the span.
-    values: HashMap<&'a str, serde_json::Value>,
+    values: HashMap<String, serde_json::Value>,
 
     /// The primary message of an event, if captured.
     message: Option<String>,
 }
 
-impl<'a> Storage<'a> {
+impl Storage {
     /// Returns `true` if `key` is reserved by the logging infrastructure and cannot be recorded
     /// via [`Self::record_value`].
     ///
@@ -60,18 +64,18 @@ impl<'a> Storage<'a> {
     ///
     /// If `key` is reserved (see [`is_reserved()`][Self::is_reserved]), a warning is logged,
     /// and the value is not recorded.
-    pub fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
+    pub fn record_value(&mut self, key: &str, value: serde_json::Value) {
         if Self::is_reserved(key) {
             tracing::warn!(
                 "Attempting to record a reserved key `{key}` (value: {value:?}). Skipping."
             );
         } else {
-            self.values.insert(key, value);
+            self.values.insert(key.to_owned(), value);
         }
     }
 
     /// Returns the key-value pairs recorded in this storage.
-    pub fn values(&self) -> &HashMap<&'a str, serde_json::Value> {
+    pub fn values(&self) -> &HashMap<String, serde_json::Value> {
         &self.values
     }
 
@@ -94,7 +98,7 @@ impl<'a> Storage<'a> {
         all(not(feature = "tracing-storage-api"), not(test)),
         expect(dead_code)
     )]
-    pub fn with_current_span<T>(f: impl FnOnce(&Storage<'_>) -> T) -> Option<T> {
+    pub fn with_current_span<T>(f: impl FnOnce(&Storage) -> T) -> Option<T> {
         use tracing_subscriber::{Registry, registry::LookupSpan};
 
         tracing::Span::current()
@@ -102,7 +106,7 @@ impl<'a> Storage<'a> {
                 let registry = dispatch.downcast_ref::<Registry>()?;
                 let span = registry.span(id)?;
                 let extensions = span.extensions();
-                let storage = extensions.get::<Storage<'_>>()?;
+                let storage = extensions.get::<Storage>()?;
 
                 Some(f(storage))
             })
@@ -123,7 +127,7 @@ impl<'a> Storage<'a> {
         all(not(feature = "tracing-storage-api"), not(test)),
         expect(dead_code)
     )]
-    pub fn with_current_span_mut<T>(f: impl FnOnce(&mut Storage<'_>) -> T) -> Option<T> {
+    pub fn with_current_span_mut<T>(f: impl FnOnce(&mut Storage) -> T) -> Option<T> {
         use tracing_subscriber::{Registry, registry::LookupSpan};
 
         tracing::Span::current()
@@ -131,7 +135,7 @@ impl<'a> Storage<'a> {
                 let registry = dispatch.downcast_ref::<Registry>()?;
                 let span = registry.span(id)?;
                 let mut extensions = span.extensions_mut();
-                let storage = extensions.get_mut::<Storage<'_>>()?;
+                let storage = extensions.get_mut::<Storage>()?;
 
                 Some(f(storage))
             })
@@ -140,7 +144,7 @@ impl<'a> Storage<'a> {
 }
 
 // Implement `Visit` to capture span or event fields into the `Storage` map.
-impl Visit for Storage<'_> {
+impl Visit for Storage {
     fn record_f64(&mut self, field: &Field, value: f64) {
         if field.name() == super::keys::MESSAGE {
             if self.message.is_none() {
@@ -230,7 +234,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
         let mut visitor = if let Some(parent_span) = span.parent() {
             parent_span
                 .extensions()
-                .get::<Storage<'_>>()
+                .get::<Storage>()
                 .cloned()
                 .unwrap_or_default()
         } else {
@@ -250,7 +254,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
 
         #[expect(clippy::expect_used)]
         let visitor = extensions
-            .get_mut::<Storage<'_>>()
+            .get_mut::<Storage>()
             .expect("span does not have storage in `on_record()`");
 
         values.record(visitor);
@@ -282,16 +286,16 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
             .unwrap_or(0);
 
         // Propagate persistent keys to parent
-        if let Some(storage) = span.extensions().get::<Storage<'_>>() {
+        if let Some(storage) = span.extensions().get::<Storage>() {
             storage
                 .values
                 .iter()
-                .filter(|(k, _v)| self.persistent_keys.contains(*k))
+                .filter(|(k, _v)| self.persistent_keys.contains(k.as_str()))
                 .for_each(|(k, v)| {
                     span.parent().and_then(|parent_span| {
                         parent_span
                             .extensions_mut()
-                            .get_mut::<Storage<'_>>()
+                            .get_mut::<Storage>()
                             .map(|parent_storage| parent_storage.record_value(k, v.to_owned()))
                     });
                 });
@@ -300,7 +304,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
         let mut extensions = span.extensions_mut();
         #[expect(clippy::expect_used)]
         let visitor = extensions
-            .get_mut::<Storage<'_>>()
+            .get_mut::<Storage>()
             .expect("span does not have storage in `on_close()`");
 
         // Record elapsed time in the span's storage


### PR DESCRIPTION
## Summary

- Changes `Storage` HashMap keys from `&'a str` to `Cow<'static, str>`, removing the lifetime parameter
- Compile-time field names (from `#[instrument]` and `span!()`) use `Cow::Borrowed(&'static str)` — zero allocation, just a pointer copy
- Runtime-determined field names use `Cow::Owned(String)` — owned by Storage and freed when the span closes
- `record_value` now accepts `impl Into<Cow<'static, str>>` — callers can pass `&'static str`, `String`, or `Cow<'static, str>` directly

## Motivation

Applications that need config-driven field renaming, static value injection, or per-request metadata relay into tracing spans currently must use `Box::leak` to satisfy `Storage::record_value`'s `&'a str` requirement. For per-request dynamic keys, this causes unbounded memory growth.

The `Cow` approach gives the best of both worlds:
- **Declared fields** (`#[instrument]`, `span!()`) — `field.name()` returns `&'static str`, stored as `Cow::Borrowed` with zero allocation
- **Runtime fields** (config, headers) — `String` converts to `Cow::Owned`, freed when span closes

See #23 for the full discussion of use cases and alternatives considered.

## Backward Compatibility

| API | Change | Breaking? |
|-----|--------|-----------|
| `record_value(key: &'a str, ...)` | → `record_value(key: impl Into<Cow<'static, str>>, ...)` | No — `&'static str` still works |
| `values()` return type | `&HashMap<&'a str, Value>` → `&HashMap<Cow<'static, str>, Value>` | No — `Cow` implements `Borrow<str>`, so `.get("key")` still works |
| `Storage<'a>` struct | → `Storage` (no lifetime) | No — callers using `Storage<'_>` still compile |
| `Visit` trait impl | Uses `Cow::Borrowed(field.name())` internally | No — trait interface unchanged |
| `on_close()` persistent keys | `.contains(k.as_ref())` | No — internal |

## Performance

- Declared span fields: **zero allocation** — `Cow::Borrowed` stores the `&'static str` pointer directly (8 bytes vs 24 bytes for `String`)
- Runtime fields: `Cow::Owned(String)` — same cost as the `String` approach, freed when span closes
- `Cow<'static, str>` is 24 bytes per key (pointer + length + discriminant) vs 8 bytes for `&str` — modest overhead for the flexibility gained

## Test plan

- [x] All 14 existing unit tests pass unchanged
- [x] All 3 doc-tests pass unchanged
- [x] `cargo test -p log_utils --all-features` — clean
- [x] `cargo clippy -p log_utils --all-features` — clean

Closes #23