### PR TITLE
fix(log_utils): suppress clippy::use_self on Storage span accessors

### DIFF
--- a/crates/log_utils/src/tracing/storage.rs
+++ b/crates/log_utils/src/tracing/storage.rs
@@ -94,6 +94,7 @@ impl<'a> Storage<'a> {
         all(not(feature = "tracing-storage-api"), not(test)),
         expect(dead_code)
     )]
+    #[allow(clippy::use_self)]
     pub fn with_current_span<T>(f: impl FnOnce(&Storage<'_>) -> T) -> Option<T> {
         use tracing_subscriber::{Registry, registry::LookupSpan};
 
@@ -123,6 +124,7 @@ impl<'a> Storage<'a> {
         all(not(feature = "tracing-storage-api"), not(test)),
         expect(dead_code)
     )]
+    #[allow(clippy::use_self)]
     pub fn with_current_span_mut<T>(f: impl FnOnce(&mut Storage<'_>) -> T) -> Option<T> {
         use tracing_subscriber::{Registry, registry::LookupSpan};
 


### PR DESCRIPTION
## Summary

- Add `#[allow(clippy::use_self)]` on `with_current_span` and `with_current_span_mut` methods

`Storage<'a>` cannot use `Self` in `extensions.get::<T>()` / `extensions.get_mut::<T>()` because `T` requires `'static`, but `Self` resolves to `Storage<'a>`. The clippy lint `use_self` fires but the suggested fix doesn't compile.

## Test plan

- [x] `cargo clippy -p log_utils --all-features` passes