### PR TITLE
chore(metrics_utils): re-export `AsyncInstrument` and `Observable*` instruments from `opentelemetry` crate

### DIFF
--- a/crates/metrics_utils/src/opentelemetry.rs
+++ b/crates/metrics_utils/src/opentelemetry.rs
@@ -8,7 +8,10 @@ mod macros;
 #[doc(hidden)]
 pub use ::opentelemetry::{
     KeyValue, Value, global,
-    metrics::{Counter, Gauge, Histogram, Meter, UpDownCounter},
+    metrics::{
+        AsyncInstrument, Counter, Gauge, Histogram, Meter, ObservableCounter, ObservableGauge,
+        ObservableUpDownCounter, UpDownCounter,
+    },
 };
 #[cfg(feature = "opentelemetry-otlp")]
 pub use opentelemetry_sdk::metrics::Temporality;


### PR DESCRIPTION
This PR just re-exports `AsyncInstrument`, `ObservableCounter`, `ObservableGauge`, `ObservableUpDownCounter` types from the `metrics_utils` crate